### PR TITLE
Update dependency mocha to ~1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "requirejs": "~2.1.10"
   },
   "devDependencies": {
-    "mocha": "~1.17.0",
+    "mocha": "~1.21.0",
     "karma": "~0.10.9"
   },
   "scripts": {


### PR DESCRIPTION
This Pull Request updates dependency [mocha](https://github.com/mochajs/mocha) from `~1.17.0` to `~1.21.0`



<details>
<summary>Release Notes</summary>

### [`v1.18.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1180--2014-03-13)

- add: promise support (#&#8203;329)
- add: named before/after hooks (#&#8203;966)

---

### [`v1.18.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1181--2014-03-18)

- fix: named before/after hooks in bdd, tdd, qunit interfaces (#&#8203;1161)

---

### [`v1.18.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1182--2014-03-18)

- fix: html runner was prevented from using #mocha as the default root el (#&#8203;1162)

---

### [`v1.19.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1190--2014-05-17)

- add: browser script option to package.json
- add: export file in Mocha.Test objects (#&#8203;1174)
- add: add docs for wrapped node flags
- fix: mocha.run() to return error status in browser (#&#8203;1216)
- fix: clean() to show failure details (#&#8203;1205)
- fix: regex that generates html for new keyword (#&#8203;1201)
- fix: sibling suites have inherited but separate contexts (#&#8203;1164)

---

### [`v1.20.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1200--2014-05-28)

- add: filenames to suite objects (#&#8203;1222)

---

### [`v1.20.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1201--2014-06-03)

- update: should dev dependency to ~4.0.0 (#&#8203;1231)

---

### [`v1.21.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1210--2014-07-23)

- add: --no-timeouts option (#&#8203;1262, #&#8203;1268)
- add: --*- deprecation node flags (#&#8203;1217)
- add: --watch-extensions argument (#&#8203;1247)
- change: spec reporter is default (#&#8203;1228)
- fix: diff output showing incorrect +/- (#&#8203;1182)
- fix: diffs of circular structures (#&#8203;1179)
- fix: re-render the progress bar when progress has changed only (#&#8203;1151)
- fix support for environments with global and window (#&#8203;1159)
- fix: reverting to previously defined onerror handler (#&#8203;1178)
- fix: stringify non error objects passed to done() (#&#8203;1270)
- fix: using local ui, reporters (#&#8203;1267)
- fix: cleaning es6 arrows (#&#8203;1176)
- fix: don't include attrs in failure tag for xunit (#&#8203;1244)
- fix: fail tests that return a promise if promise is rejected w/o a reason (#&#8203;1224)
- fix: showing failed tests in doc reporter (#&#8203;1117)
- fix: dot reporter dots being off (#&#8203;1204)
- fix: catch empty throws (#&#8203;1219)
- fix: honoring timeout for sync operations (#&#8203;1242)
- update: growl to 1.8.0

---

### [`v1.21.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1215--2014-10-11)

- fix: build for NodeJS v0.6.x
- fix: do not attempt to highlight syntax when non-HTML reporter is used
- update: escape-string-regexp to 1.0.2.
- fix: botched indentation in canonicalize()
- fix: .gitignore: ignore .patch and .diff files
- fix: changed 'Catched' to 'Caught' in uncaught exception error handler messages
- add: `pending` field for json reporter
- fix: Runner.prototype.uncaught: don't double-end runnables that already have a state.
- fix: --recursive, broken by f0facd2e
- update: replaces escapeRegexp with the escape-string-regexp package.
- update: commander to 2.3.0.
- update: diff to 1.0.8.
- fix: ability to disable syntax highlighting (#&#8203;1329)
- fix: added empty object to errorJSON() call to catch when no error is present
- fix: never time out after calling enableTimeouts(false)
- fix: timeout(0) will work at suite level (#&#8203;1300)
- Fix for --watch+only() issue (#&#8203;888 )
- fix: respect err.showDiff, add Base reporter test (#&#8203;810)

---

</details>