### PR TITLE
Update dependency requirejs to ~2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "karma-phantomjs-launcher": "~0.1.1",
     "karma-requirejs": "~0.2.1",
     "karma-script-launcher": "~0.1.0",
-    "requirejs": "~2.1.10"
+    "requirejs": "~2.3.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0",


### PR DESCRIPTION
This Pull Request updates dependency [requirejs](https://github.com/jrburke/r.js) from `~2.1.10` to `~2.3.0`




<details>
<summary>Commits</summary>

#### v2.2.0
-   [`983d82a`](https://github.com/jrburke/r.js/commit/983d82a95c08b0588b8fe7eeeb5c69603a2bec1d) Account for wrap config in sourcemap generation
-   [`4373364`](https://github.com/jrburke/r.js/commit/43733641cb04b6afe941e028893a9a2c1a7f34fa) Fixes #&#8203;1461, leave absolute file paths alone
-   [`5cd88c8`](https://github.com/jrburke/r.js/commit/5cd88c87839b3c2e72d872a90436f0270d611fd0) snapshot, indicate version is past 2.1.22 release
-   [`5765c57`](https://github.com/jrburke/r.js/commit/5765c576cd96c825cf0902333e61f21564eba4a9) Fixes #&#8203;888, fixes #&#8203;839, fixes #&#8203;890, set proper paths to compiler.jar, and set opt level to avoid 64KB limit error
-   [`2a96f00`](https://github.com/jrburke/r.js/commit/2a96f0008dafa38a2c9be2e769e8fb21a14a2a9e) Use stdout.write(..., &#x27;utf8&#x27;), not stdout.setEncoding(&#x27;utf8&#x27;)
-   [`bff2f04`](https://github.com/jrburke/r.js/commit/bff2f04cb5ed9148eed0f6e393897a477ef97bc6) requirejs now just MIT license, requirejs/requirejs#&#8203;1502, requirejs repos moved, requirejs/requirejs#&#8203;1501
-   [`4d29b16`](https://github.com/jrburke/r.js/commit/4d29b16c36fb8d8f7907fbf142c629eb6b875955) snapshot
-   [`6877860`](https://github.com/jrburke/r.js/commit/6877860348a1a23127c80a43a7600c841140381d) requirejs now just MIT license, requirejs/requirejs#&#8203;1502, requirejs repos moved, requirejs/requirejs#&#8203;1501
-   [`991d88a`](https://github.com/jrburke/r.js/commit/991d88a7fc18f8b2723b3dfa23408ec220a83830) Improve traverse and parse performance
-   [`a83cb8c`](https://github.com/jrburke/r.js/commit/a83cb8c420261aa9306a2534ace5beeaa004ea87) Merge pull request #&#8203;898 from Enselic/master
-   [`61c5ad9`](https://github.com/jrburke/r.js/commit/61c5ad931618796bd11aba5bc15fa5a78b36f232) snapshot
-   [`f736a69`](https://github.com/jrburke/r.js/commit/f736a695975d784a5beaed9e23d41a7c6242db83) Merge pull request #&#8203;900 from petersondrew/parse-perf
-   [`c0cf463`](https://github.com/jrburke/r.js/commit/c0cf4631054503576cdbc6908d17599cea0f39f1) snapshot
-   [`54327a2`](https://github.com/jrburke/r.js/commit/54327a2e3ff3af1b1fcb0021506d62d80228d0ae) Updating jQuery Foundation related info, relates to requirejs/requirejs#&#8203;1502
-   [`beadeca`](https://github.com/jrburke/r.js/commit/beadecaf20469481490f22ef624285518f92005c) Updating jQuery Foundation related info, relates to requirejs/requirejs#&#8203;1502
-   [`e4bfc56`](https://github.com/jrburke/r.js/commit/e4bfc56ca2e4f1da72f5693c59642b59378fb37b) Updating jQuery Foundation related info, relates to requirejs/requirejs#&#8203;1502
-   [`c4d093c`](https://github.com/jrburke/r.js/commit/c4d093c9d2748237a2b75afb9e8e38fd298b9877) Test to confirm requirejs/requirejs#&#8203;1492 does not affect r.js
-   [`04d9dae`](https://github.com/jrburke/r.js/commit/04d9daedbf6f6334c9df656c648d9f1a493ae713) Re-order the testing of environments
-   [`06288a4`](https://github.com/jrburke/r.js/commit/06288a45863dcf5e1fb94269e17f51f5c8ab8ece) require.js master update
-   [`4b9c3c6`](https://github.com/jrburke/r.js/commit/4b9c3c643ca4cafb93c1cd0aa9b043cb730efa70) Merge pull request #&#8203;901 from ghostoy/reorder-test
-   [`7de1d6e`](https://github.com/jrburke/r.js/commit/7de1d6e52a02a2d99d71e3802625896d226e7bea) snapshot
-   [`abab459`](https://github.com/jrburke/r.js/commit/abab4597bc274c8a8e65e6fa93e123fda6e40921) Fixes #&#8203;880, Finding UMD definition should not stop processing of siblings.
-   [`33799fa`](https://github.com/jrburke/r.js/commit/33799fa3d5f874c1b50f460cdaa8581f409698b8) snapshot
-   [`8bd4c8f`](https://github.com/jrburke/r.js/commit/8bd4c8f6c79cbabf764273d328676f00d0d45046) Fixes #&#8203;883, uglify2 is now the only uglify option, removed uglify1 since it is out of date.
-   [`b7cbb23`](https://github.com/jrburke/r.js/commit/b7cbb2323ce0a6ade8e1a8d99d7e5e7d971d39fb) snapshot
-   [`d0e7bd4`](https://github.com/jrburke/r.js/commit/d0e7bd461b2a6aa74bde94e5910cce43ea0b264f) Fixes #&#8203;891, detect module.exports.something &#x3D; usage
-   [`35f71a8`](https://github.com/jrburke/r.js/commit/35f71a826dfee6f34e678a2eb939baf9a09d6909) snapshot
-   [`a53153b`](https://github.com/jrburke/r.js/commit/a53153b5fab65644ceab45944504a49850cc06c3) Fixes #&#8203;722, writeBuildTxt config to avoid writing build.txt file
-   [`25907d2`](https://github.com/jrburke/r.js/commit/25907d2577c6ddcec172e51c05c02929639a2128) snapshot
-   [`cfe00a9`](https://github.com/jrburke/r.js/commit/cfe00a9399720654cfecd75da7bbeff62d1b920d) Fixes #&#8203;863, increase default waitSeconds time
-   [`4119fdd`](https://github.com/jrburke/r.js/commit/4119fdd6dfac3b55091f927258d040f6817e93b8) Merge pull request #&#8203;875 from abrobston/sourcemap-wrap
-   [`1114d81`](https://github.com/jrburke/r.js/commit/1114d81d33adbe69e3be4b029048b99aea075df1) Fixes requirejs/requirejs#&#8203;1463, allow wrap.start/endFile to be arrays on command line
-   [`fe3d321`](https://github.com/jrburke/r.js/commit/fe3d3211d2cd0371fe249a0d0217023899a4a2ea) snapshot
-   [`e3d70e0`](https://github.com/jrburke/r.js/commit/e3d70e0999519500db6fffe5c259b7e1544d6456) Relates to #&#8203;892, update esprima to 2.7.2
-   [`8e23461`](https://github.com/jrburke/r.js/commit/8e2346167c432554c52edf74563583c78f5e19ab) Fixes #&#8203;613, option to write out bundles config
-   [`98a9949`](https://github.com/jrburke/r.js/commit/98a9949480d68a781c8d6fc4ce0a07c16a2c8a2a) snapshot
-   [`49b7a28`](https://github.com/jrburke/r.js/commit/49b7a280e50ddeb5b150c4eeca356fb3a07ca1ac) Rev for 2.2.0
#### v2.3.0
-   [`67924d2`](https://github.com/jrburke/r.js/commit/67924d205978c917c78b02ad56fbc60ca6ce8183) verbatim updated with sample examples
-   [`b45117f`](https://github.com/jrburke/r.js/commit/b45117f5e4e07b7061b03f1eb6ec8cc12e2eb2fc) Test update to match requirejs/text#&#8203;119
-   [`27594a4`](https://github.com/jrburke/r.js/commit/27594a409b3d37427ec33bdc151ae8a9f67d6b2b) Merge pull request #&#8203;908 from deveeduttam/patch-1
-   [`1bc77e5`](https://github.com/jrburke/r.js/commit/1bc77e5c46d66abad864c49bcbf6072f1d396661) Fixes #&#8203;921, avoid max arg list to push.apply
-   [`dec871d`](https://github.com/jrburke/r.js/commit/dec871d4823e051e35fb910eeee861b5a7801e09) rev to dev version
-   [`db3d0b0`](https://github.com/jrburke/r.js/commit/db3d0b00177d8cb05c3714daa97d8447e294cffc) snapshot
-   [`fda20ce`](https://github.com/jrburke/r.js/commit/fda20ceafff5cc475fab4f0b5712565fffbf0b50) Updating an older pull request
-   [`e7400fe`](https://github.com/jrburke/r.js/commit/e7400fe402ea436efe29e5c6769cf3f25b11fdfb) There&#x27;s no uglify2, just uglify
-   [`f667f33`](https://github.com/jrburke/r.js/commit/f667f336391a21996b6b732869980cc9662400f4) Merge pull request #&#8203;926 from homedepotlabs/sourcemaps_licensecomments
-   [`90f1965`](https://github.com/jrburke/r.js/commit/90f19653c5449df5fe8bd683cae4358bc8dfcf90) Fixes #&#8203;927, update uglify and esprima
-   [`465c0e4`](https://github.com/jrburke/r.js/commit/465c0e45b19196b24aad3cb3ab148ad639d07a66) snapshot
-   [`84f4adb`](https://github.com/jrburke/r.js/commit/84f4adbf2c42dcc63fd5b64f9c1723c0fbb3e329) Fixes #&#8203;919, do not copy main named modules file if in rawText
-   [`e601316`](https://github.com/jrburke/r.js/commit/e60131660a1d5361f295357a739ea6a0442e7667) snapshot
-   [`fd1f9a8`](https://github.com/jrburke/r.js/commit/fd1f9a81135aa444da2e44412e92d455b0c419b7) Rev to 2.3.0
#### v2.3.1
-   [`59a9c8c`](https://github.com/jrburke/r.js/commit/59a9c8cc7145e97a42f6472db7d3e4e5b45ba4d8) Fixes #&#8203;929, uglify&#x27;s addFile declaration and 0.10/0.12 nodes
-   [`90fe79c`](https://github.com/jrburke/r.js/commit/90fe79c7b5c1a04457ded173bad4abfac8521a10) Rev for 2.3.1
#### v2.3.2
-   [`c8d13e7`](https://github.com/jrburke/r.js/commit/c8d13e7322cea0da9ea25faa621223a94d625e50) rev past 2.3.1 version
-   [`7f03264`](https://github.com/jrburke/r.js/commit/7f0326491122cef722f913f9fe5e11e2824a772a) Fixes #&#8203;933, detect for setTimeout availability, snapshot
-   [`02503ad`](https://github.com/jrburke/r.js/commit/02503ad46f09294e9a980f793be5c9a56571c0df) Rev to 2.3.2
#### v2.3.3
-   [`dac436a`](https://github.com/jrburke/r.js/commit/dac436aa8429059663aa55a14c76cc5864e0a183) Fix two minor typos in README.md
-   [`7774bc9`](https://github.com/jrburke/r.js/commit/7774bc96d3acd6723f3cfb37e032eaca307564f0) Merge pull request #&#8203;939 from jorrit/patch-1
-   [`268fa77`](https://github.com/jrburke/r.js/commit/268fa7703e0fa2d1f4482c649d9a493740915260) Rev past 2.3.2
-   [`cc7bfe7`](https://github.com/jrburke/r.js/commit/cc7bfe7e4dcee708ad0bd0d6e3de435363d3ff3a) Fixes #&#8203;924, some files only have carriage returns, no newlines
-   [`d8dca4c`](https://github.com/jrburke/r.js/commit/d8dca4cb281ed89da305eed2f171b5b3f0eadc30) snapshot
-   [`5d84eea`](https://github.com/jrburke/r.js/commit/5d84eeae4fc92c45c71a68536acaad6495df769e) Merge branch &#x27;master&#x27; of github.com:requirejs/r.js
-   [`baf9d1d`](https://github.com/jrburke/r.js/commit/baf9d1d0e64539faf7d97f84a81a14e5b37dff4f) Revert &quot;Fixes #&#8203;924, some files only have carriage returns, no newlines&quot;
-   [`aa349c7`](https://github.com/jrburke/r.js/commit/aa349c72576dfb08ee14f599f77c2f8d63ec39e2) snapshot
-   [`4b3f5c5`](https://github.com/jrburke/r.js/commit/4b3f5c59c65ad6d568fc8c834bd39ec1caf1a246) Fixes #&#8203;943 uglify mangleProperties, also upgrade to uglify 2.7.4
-   [`1f463aa`](https://github.com/jrburke/r.js/commit/1f463aa121dedeff816bb3d4e7bef5bddd1590a5) snapshot
-   [`7871170`](https://github.com/jrburke/r.js/commit/78711703d7ee20c1a3ffe4466aeefb63732d2717) stdout.write uses encoding directly instead of setting encoding first
-   [`b220d2c`](https://github.com/jrburke/r.js/commit/b220d2c61dd61cc8e5b16c0e1e436df1c232c734) Merge pull request #&#8203;947 from Dietatko/master
-   [`4744d94`](https://github.com/jrburke/r.js/commit/4744d94fa13e8b239600a5c3fa7c2b7ce2757509) snapshot
-   [`c6f9375`](https://github.com/jrburke/r.js/commit/c6f9375069678b2d656ac3ca586b98816cd838f4) Refs #&#8203;942, upgrade esprima
-   [`fd9de76`](https://github.com/jrburke/r.js/commit/fd9de76d7d3cc0f1b5ded369f780744fa86d6b2c) snapshot
-   [`7ecf9c2`](https://github.com/jrburke/r.js/commit/7ecf9c2c9b9fc5a24609b6dc512ed0859b725dcc) Refs #&#8203;942, update uglify to 2.7.5
-   [`003a611`](https://github.com/jrburke/r.js/commit/003a611d474745cba5bd1eceb2fc9cb16c985822) snapshot
-   [`407215c`](https://github.com/jrburke/r.js/commit/407215c02eb080eea457d94d0a3195f8443cf15a) Fixes #&#8203;944 Plugin undef should use map config
-   [`4ba1dbc`](https://github.com/jrburke/r.js/commit/4ba1dbcb21252a6d241cd9aa80af34d10daf4213) snapshot
-   [`3941a85`](https://github.com/jrburke/r.js/commit/3941a85d3edea5d9b18c5bdbea60ab27ca2b016e) 2.3.3
#### v2.3.4
-   [`d689d89`](https://github.com/jrburke/r.js/commit/d689d89657c7e8922b5c281e3fee464b0fa7ed76) Fixes #&#8203;963, update to esprima 4
-   [`9c414f6`](https://github.com/jrburke/r.js/commit/9c414f6f259d4c4f1d66c9748badeaad60b86ed4) version rev and snapshot
-   [`c5ba493`](https://github.com/jrburke/r.js/commit/c5ba493d4c5ba1f3e044aea1a0ddf93eeb543101) rev for 2.3.4
#### v2.3.5
-   [`bad2808`](https://github.com/jrburke/r.js/commit/bad280805b18748eeccfa57797c19072c8a54a2d) Add a test for uglified license comments with source maps.
-   [`9b325fc`](https://github.com/jrburke/r.js/commit/9b325fc9ffa3b4f80684449a7122efd439eef4ed) Fix the accidental doubling of license comments when generating source maps.
-   [`a5752b0`](https://github.com/jrburke/r.js/commit/a5752b005319d233f8ab5284e636d1b2002079ed) Merge pull request #&#8203;965 from elliot-nelson/license-comments
-   [`8cba8b2`](https://github.com/jrburke/r.js/commit/8cba8b24395fd2d9c5f497e495c636da37de8f63) Relates to #&#8203;965, remove local preamble var no longer used
-   [`c1a1415`](https://github.com/jrburke/r.js/commit/c1a14154a8172adcda552758ef72952800f97023) snapshot
-   [`9e7ab60`](https://github.com/jrburke/r.js/commit/9e7ab603076dca5ef9297aaccbad6c0d6d8434d7) Relates to #&#8203;959, document ES5 limitation on included uglifyjs
-   [`496cc41`](https://github.com/jrburke/r.js/commit/496cc413b2a385afcaf53496c98609aedfaf41e1) Relates to #&#8203;959, update uglify to 2.8.29
-   [`8d2e387`](https://github.com/jrburke/r.js/commit/8d2e3870a381aa412aef292efb51cf3e6052e299) snapshot
-   [`948a0c8`](https://github.com/jrburke/r.js/commit/948a0c89ff665c4c46a96aec779acfc4ce3f61e9) Rev for 2.3.5

</details>