### PR TITLE
Update dependency mocha to ~5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "requirejs": "~2.1.10"
   },
   "devDependencies": {
-    "mocha": "~1.17.0",
+    "mocha": "~5.0.0",
     "karma": "~0.10.9"
   },
   "scripts": {


### PR DESCRIPTION
This Pull Request updates dependency [mocha](https://github.com/mochajs/mocha) from `~1.17.0` to `~5.0.0`



<details>
<summary>Release Notes</summary>

### [`v1.18.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1180--2014-03-13)

- add: promise support (#&#8203;329)
- add: named before/after hooks (#&#8203;966)

---

### [`v1.18.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1181--2014-03-18)

- fix: named before/after hooks in bdd, tdd, qunit interfaces (#&#8203;1161)

---

### [`v1.18.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1182--2014-03-18)

- fix: html runner was prevented from using #mocha as the default root el (#&#8203;1162)

---

### [`v1.19.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1190--2014-05-17)

- add: browser script option to package.json
- add: export file in Mocha.Test objects (#&#8203;1174)
- add: add docs for wrapped node flags
- fix: mocha.run() to return error status in browser (#&#8203;1216)
- fix: clean() to show failure details (#&#8203;1205)
- fix: regex that generates html for new keyword (#&#8203;1201)
- fix: sibling suites have inherited but separate contexts (#&#8203;1164)

---

### [`v1.20.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1200--2014-05-28)

- add: filenames to suite objects (#&#8203;1222)

---

### [`v1.20.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1201--2014-06-03)

- update: should dev dependency to ~4.0.0 (#&#8203;1231)

---

### [`v1.21.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1210--2014-07-23)

- add: --no-timeouts option (#&#8203;1262, #&#8203;1268)
- add: --*- deprecation node flags (#&#8203;1217)
- add: --watch-extensions argument (#&#8203;1247)
- change: spec reporter is default (#&#8203;1228)
- fix: diff output showing incorrect +/- (#&#8203;1182)
- fix: diffs of circular structures (#&#8203;1179)
- fix: re-render the progress bar when progress has changed only (#&#8203;1151)
- fix support for environments with global and window (#&#8203;1159)
- fix: reverting to previously defined onerror handler (#&#8203;1178)
- fix: stringify non error objects passed to done() (#&#8203;1270)
- fix: using local ui, reporters (#&#8203;1267)
- fix: cleaning es6 arrows (#&#8203;1176)
- fix: don't include attrs in failure tag for xunit (#&#8203;1244)
- fix: fail tests that return a promise if promise is rejected w/o a reason (#&#8203;1224)
- fix: showing failed tests in doc reporter (#&#8203;1117)
- fix: dot reporter dots being off (#&#8203;1204)
- fix: catch empty throws (#&#8203;1219)
- fix: honoring timeout for sync operations (#&#8203;1242)
- update: growl to 1.8.0

---

### [`v1.21.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;1215--2014-10-11)

- fix: build for NodeJS v0.6.x
- fix: do not attempt to highlight syntax when non-HTML reporter is used
- update: escape-string-regexp to 1.0.2.
- fix: botched indentation in canonicalize()
- fix: .gitignore: ignore .patch and .diff files
- fix: changed 'Catched' to 'Caught' in uncaught exception error handler messages
- add: `pending` field for json reporter
- fix: Runner.prototype.uncaught: don't double-end runnables that already have a state.
- fix: --recursive, broken by f0facd2e
- update: replaces escapeRegexp with the escape-string-regexp package.
- update: commander to 2.3.0.
- update: diff to 1.0.8.
- fix: ability to disable syntax highlighting (#&#8203;1329)
- fix: added empty object to errorJSON() call to catch when no error is present
- fix: never time out after calling enableTimeouts(false)
- fix: timeout(0) will work at suite level (#&#8203;1300)
- Fix for --watch+only() issue (#&#8203;888 )
- fix: respect err.showDiff, add Base reporter test (#&#8203;810)

---

### [`v2.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;200--2014-10-21)

- remove: support for node 0.6.x, 0.4.x
- fix: landing reporter with non ansi characters (#&#8203;211)
- fix: html reporter - preserve query params when navigating to suites/tests (#&#8203;1358)
- fix: json stream reporter add error message to failed test
- fix: fixes for visionmedia -> mochajs
- fix: use stdio, fixes node deprecation warnings (#&#8203;1391)

---

### [`v2.1.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;210--2014-12-23)

- showDiff: don’t stringify strings
- Clean up unused module dependencies.
- Filter zero-length strings from mocha.opts
- only write to stdout in reporters
- Revert "only write to stdout in reporters"
- Print colored output only to a tty
- update summary in README.md
- rename Readme.md/History.md to README.md/HISTORY.md because neurotic
- add .mailmap to fix "git shortlog" or "git summary" output
- fixes #&#8203;1461: nyan-reporter now respects Base.useColors, fixed bug where Base.color would not return a string when str wasn't a string.
- Use existing test URL builder in failed replay links
- modify .travis.yml: use travis_retry; closes #&#8203;1449
- fix -t 0 behavior; closes #&#8203;1446
- fix tests (whoops)
- improve diff behavior
- Preserve pathname when linking to individual tests
- Fix test
- Tiny typo in comments fixed
- after hooks now being called on failed tests when using bail, fixes #&#8203;1093
- fix throwing undefined/null now makes tests fail, fixes #&#8203;1395
- compiler extensions are added as watched extensions, removed non-standard extensions from watch regex, resolves #&#8203;1221
- prefix/namespace for suite titles in markdown reporter, fixes #&#8203;554
- fix more bad markdown in CONTRIBUTING.md
- fix bad markdown in CONTRIBUTING.md
- add setImmediate/clearImmediate to globals; closes #&#8203;1435
- Fix buffer diffs (closes #&#8203;1132, closes #&#8203;1433)
- add a CONTRIBUTING.md.  closes #&#8203;882
- fix intermittent build failures (maybe). closes #&#8203;1407
- add Slack notification to .travis.yml
- Fix slack link
- Add slack room to readme
- Update maintainers
- update maintainers and contributors
- resolves #&#8203;1393: kill children with more effort on SIGINT
- xunit reporter support for optionally writing to a file
- if a reporter has a .done method, call it before exiting
- add support for reporter options
- only write to stdout in reporters

---

### [`v2.2.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;220--2015-03-06)

- Update mocha.js
- Add --fgrep. Use grep for RegExp, fgrep for str
- Ignore async global errors after spec resolution
- Fixing errors that prevent mocha.js from loading in the browser - fixes #&#8203;1558
- fix(utils): issue #&#8203;1558 + make
- add ability to delay root suite; closes #&#8203;362, closes #&#8203;1124
- fix insanity in http tests
- update travis: add node 0.12, add gitter, remove slack
- building
- resolve #&#8203;1548: ensure the environment's "node" executable is used
- reporters/base: use supports-color to detect colorable term
- travis: use docker containers
- small fix: commander option for --expose-gc
- Ignore asynchronous errors after global failure
- Improve error output when a test fails with a non-error
- updated travis badge, uses svg instead of img
- Allow skip from test context for #&#8203;332
- [JSHINT] Unnecessary semicolon fixed in bin/_mocha
- Added a reminder about the done() callback to test timeout error messages
- fixes #&#8203;1496, in Mocha.run(fn), check if fn exists before executing it, added tests too
- Add Harmony Proxy flag for iojs
- test(utils|ms|*): test existing units
- add support for some iojs flags
- fix(utils.stringify): issue #&#8203;1229, diff viewer
- Remove slack link
- Prevent multiple 'grep=' querystring params in html reporter
- Use grep as regexp (close #&#8203;1381)
- utils.stringify should handle objects without an Object prototype
- in runnable test, comparing to undefined error's message rather than a literal
- Fix test running output truncation on async STDIO
- amended for deprecated customFds option in child_process

---

### [`v2.2.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;221--2015-03-09)

- Fix passing of args intended for node/iojs.

---

### [`v2.2.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;223--2015-04-07)

- fix(reporter/base): string diff - issue #&#8203;1241
- fix(reporter/base): string diff - issue #&#8203;1241
- fix(reporter/base): don't show diffs for errors without expectation
- fix(reporter/base): don't assume error message is first line of stack
- improve: dry up reporter/base test
- fix(reporter/base): explicitly ignore showDiff #&#8203;1614
- Add iojs to travis build
- Pass `--allow-natives-syntax` flag to node.
- Support --harmony_classes flag for io.js
- Fix 1556: Update utils.clean to handle newlines in func declarations
- Fix 1606: fix err handling in IE <= 8 and non-ES5 browsers
- Fix 1585: make _mocha executable again
- chore(package.json): add a8m as a contributor
- Fixed broken link on html-cov reporter
- support --es_staging flag
- fix issue where menu overlaps content.
- update contributors in package.json
- Remove trailing whitespace from reporter output
- Remove contributors list from readme
- log third-party reporter errors
- [Fix] Exclude not own properties when looping on options
- fix: support node args in mocha.opts (close #&#8203;1573)
- fix(reporter/base): string diff - issue #&#8203;1241

---

### [`v2.2.4`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;224--2015-04-08)

- Load mocha.opts in _mocha for now (close #&#8203;1645)

---

### [`v2.2.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;225--2015-05-14)

- [#&#8203;1699] - Upgrade jsdiff to v1.4.0 ([@&#8203;nylen])
- [#&#8203;1648] - fix diff background colors in the console ([@&#8203;nylen])
- [#&#8203;1327] - fix tests running twice, a regression issue. ([#&#8203;1686], [@&#8203;danielstjules])
- [#&#8203;1675] - add integration tests ([@&#8203;danielstjules])
- [#&#8203;1682] - use a valid SPDX license identifier in package.json ([@&#8203;kemitchell])
- [#&#8203;1660] - fix assertion of invalid dates ([#&#8203;1661], [@&#8203;a8m])
- [#&#8203;1241] - fix issue with multiline diffs appearing as single line ([#&#8203;1655], [@&#8203;a8m])

[#&#8203;1699]: `https://github.com/mochajs/mocha/issues/1699`
[#&#8203;1648]: `https://github.com/mochajs/mocha/issues/1648`
[#&#8203;1327]: `https://github.com/mochajs/mocha/issues/1327`
[#&#8203;1686]: `https://github.com/mochajs/mocha/issues/1686`
[#&#8203;1675]: `https://github.com/mochajs/mocha/issues/1675`
[#&#8203;1682]: `https://github.com/mochajs/mocha/issues/1682`
[#&#8203;1660]: `https://github.com/mochajs/mocha/issues/1660`
[#&#8203;1661]: `https://github.com/mochajs/mocha/issues/1661`
[#&#8203;1241]: `https://github.com/mochajs/mocha/issues/1241`
[#&#8203;1655]: `https://github.com/mochajs/mocha/issues/1655`
[@&#8203;nylen]: https://github.com/nylen
[@&#8203;danielstjules]: https://github.com/danielstjules
[@&#8203;kemitchell]: https://github.com/kemitchell
[@&#8203;a8m]: https://github.com/a8m

---

### [`v2.3.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;230--2015-08-30)

- [#&#8203;553] - added --allowUncaught option ([@&#8203;amsul])
- [#&#8203;1490] - Allow --async-only to be satisfied by returning a promise ([@&#8203;jlai])
- [#&#8203;1829] - support --max-old-space-size ([@&#8203;gigadude])
- [#&#8203;1811] - upgrade Jade dependency ([@&#8203;outsideris])
- [#&#8203;1769] - Fix async hook error handling ([@&#8203;ajaykodali])
- [#&#8203;1230] - More descriptive beforeEach/afterEach messages ([@&#8203;duncanbeevers])
- [#&#8203;1787] - Scope loading behaviour instead of using early return ([@&#8203;aryeguy])
- [#&#8203;1789] - Fix: html-runner crashing ([@&#8203;sunesimonsen])
- [#&#8203;1749] - Fix maximum call stack error on large amount of tests ([@&#8203;tinganho])
- [#&#8203;1230] - Decorate failed hook titles with test title ([@&#8203;duncanbeevers])
- [#&#8203;1260] - Build using Browserify ([@&#8203;ndhoule])
- [#&#8203;1728] - Don't use `__proto__` ([@&#8203;ndhoule])
- [#&#8203;1781] - Fix hook error tests ([@&#8203;glenjamin])
- [#&#8203;1754] - Allow boolean --reporter-options ([@&#8203;papandreou])
- [#&#8203;1766] - Fix overly aggressive stack suppression ([@&#8203;moll])
- [#&#8203;1752] - Avoid potential infinite loop ([@&#8203;gsilk])
- [#&#8203;1761] - Fix problems running under PhantomJS ([@&#8203;chromakode])
- [#&#8203;1700] - Fix more problems running under PhantomJS ([@&#8203;jbnicolai])
- [#&#8203;1774] - Support escaped spaces in CLI options ([@&#8203;adamgruber])
- [#&#8203;1687] - Fix HTML reporter links with special chars ([@&#8203;benvinegar])
- [#&#8203;1359] - Adopt code style and enforce it using ESLint ([@&#8203;ndhoule] w/ assist from [@&#8203;jbnicolai] & [@&#8203;boneskull])
- various refactors ([@&#8203;jbnicolai])
- [#&#8203;1758] - Add cross-frame compatible Error checking ([@&#8203;outdooricon])
- [#&#8203;1741] - Remove moot `version` property from bower.json ([@&#8203;kkirsche])
- [#&#8203;1739] - Improve `HISTORY.md` ([@&#8203;rstacruz])
- [#&#8203;1730] - Support more io.js flags ([@&#8203;ryedog])
- [#&#8203;1349] - Allow HTML in HTML reporter errors ([@&#8203;papandreou] / [@&#8203;sunesimonsen])
- [#&#8203;1572] - Prevent default browser behavior for failure/pass links ([@&#8203;jschilli])
- [#&#8203;1630] - Support underscored harmony flags ([@&#8203;dominicbarnes])
- [#&#8203;1718] - Support more harmony flags ([@&#8203;slyg])
- [#&#8203;1689] - Add stack to JSON-stream reporter ([@&#8203;jonathandelgado])
- [#&#8203;1654] - Fix `ReferenceError` "location is not defined" ([@&#8203;jakemmarsh])

  [#&#8203;553]: `https://github.com/mochajs/mocha/issues/553`
  [#&#8203;1490]: `https://github.com/mochajs/mocha/issues/1490`
  [#&#8203;1829]: `https://github.com/mochajs/mocha/issues/1829`
  [#&#8203;1811]: `https://github.com/mochajs/mocha/issues/1811`
  [#&#8203;1769]: `https://github.com/mochajs/mocha/issues/1769`
  [#&#8203;1230]: `https://github.com/mochajs/mocha/issues/1230`
  [#&#8203;1787]: `https://github.com/mochajs/mocha/issues/1787`
  [#&#8203;1789]: `https://github.com/mochajs/mocha/issues/1789`
  [#&#8203;1749]: `https://github.com/mochajs/mocha/issues/1749`
  [#&#8203;1230]: `https://github.com/mochajs/mocha/issues/1230`
  [#&#8203;1260]: `https://github.com/mochajs/mocha/issues/1260`
  [#&#8203;1728]: `https://github.com/mochajs/mocha/issues/1728`
  [#&#8203;1781]: `https://github.com/mochajs/mocha/issues/1781`
  [#&#8203;1754]: `https://github.com/mochajs/mocha/issues/1754`
  [#&#8203;1766]: `https://github.com/mochajs/mocha/issues/1766`
  [#&#8203;1752]: `https://github.com/mochajs/mocha/issues/1752`
  [#&#8203;1761]: `https://github.com/mochajs/mocha/issues/1761`
  [#&#8203;1700]: `https://github.com/mochajs/mocha/issues/1700`
  [#&#8203;1774]: `https://github.com/mochajs/mocha/issues/1774`
  [#&#8203;1687]: `https://github.com/mochajs/mocha/issues/1687`
  [#&#8203;1359]: `https://github.com/mochajs/mocha/issues/1359`
  [#&#8203;1758]: `https://github.com/mochajs/mocha/issues/1758`
  [#&#8203;1741]: `https://github.com/mochajs/mocha/issues/1741`
  [#&#8203;1739]: `https://github.com/mochajs/mocha/issues/1739`
  [#&#8203;1730]: `https://github.com/mochajs/mocha/issues/1730`
  [#&#8203;1349]: `https://github.com/mochajs/mocha/issues/1349`
  [#&#8203;1572]: `https://github.com/mochajs/mocha/issues/1572`
  [#&#8203;1630]: `https://github.com/mochajs/mocha/issues/1630`
  [#&#8203;1718]: `https://github.com/mochajs/mocha/issues/1718`
  [#&#8203;1689]: `https://github.com/mochajs/mocha/issues/1689`
  [#&#8203;1654]: `https://github.com/mochajs/mocha/issues/1654`
  [@&#8203;adamgruber]: https://github.com/adamgruber
  [@&#8203;ajaykodali]: https://github.com/ajaykodali
  [@&#8203;amsul]: https://github.com/amsul
  [@&#8203;aryeguy]: https://github.com/aryeguy
  [@&#8203;benvinegar]: https://github.com/benvinegar
  [@&#8203;boneskull]: https://github.com/boneskull
  [@&#8203;chromakode]: https://github.com/chromakode
  [@&#8203;dominicbarnes]: https://github.com/dominicbarnes
  [@&#8203;duncanbeevers]: https://github.com/duncanbeevers
  [@&#8203;gigadude]: https://github.com/gigadude
  [@&#8203;glenjamin]: https://github.com/glenjamin
  [@&#8203;gsilk]: https://github.com/gsilk
  [@&#8203;jakemmarsh]: https://github.com/jakemmarsh
  [@&#8203;jbnicolai]: https://github.com/jbnicolai
  [@&#8203;jlai]: https://github.com/jlai
  [@&#8203;jonathandelgado]: https://github.com/jonathandelgado
  [@&#8203;jschilli]: https://github.com/jschilli
  [@&#8203;kkirsche]: https://github.com/kkirsche
  [@&#8203;moll]: https://github.com/moll
  [@&#8203;ndhoule]: https://github.com/ndhoule
  [@&#8203;outdooricon]: https://github.com/outdooricon
  [@&#8203;outsideris]: https://github.com/outsideris
  [@&#8203;papandreou]: https://github.com/papandreou
  [@&#8203;rstacruz]: https://github.com/rstacruz
  [@&#8203;ryedog]: https://github.com/ryedog
  [@&#8203;slyg]: https://github.com/slyg
  [@&#8203;sunesimonsen]: https://github.com/sunesimonsen
  [@&#8203;tinganho]: https://github.com/tinganho

---

### [`v2.3.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;231--2015-09-06)

- [#&#8203;1812] - Fix: Bail flag causes before() hooks to be run even after a failure ([@&#8203;aaroncrows])

  [#&#8203;1812]: `https://github.com/mochajs/mocha/issues/1812`
  [aaroncrows]: https://github.com/aaroncrows

---

### [`v2.3.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;232--2015-09-07)

- [#&#8203;1868] - Fix compatibility with older versions of NPM ([@&#8203;boneskull])

  [#&#8203;1868]: `https://github.com/mochajs/mocha/issues/1868`

---

### [`v2.3.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;233--2015-09-19)

- [#&#8203;1875] - Fix Markdown reporter exceeds maximum call stack size ([@&#8203;danielstjules])
- [#&#8203;1864] - Fix xunit missing output with --reporter-options output ([@&#8203;danielstjules])
- [#&#8203;1846] - Support all harmony flags ([@&#8203;danielstjules])
- Fix fragile xunit reporter spec ([@&#8203;danielstjules])
- [#&#8203;1669] - Fix catch uncaught errors outside test suite execution ([@&#8203;danielstjules])
- [#&#8203;1868] - Revert jade to support npm < v1.3.7 ([@&#8203;danielstjules])
- [#&#8203;1766] - Don't remove modules/components from stack trace in the browser ([@&#8203;danielstjules])
- [#&#8203;1798] - Fix correctly attribute mutiple done err with hooks ([@&#8203;danielstjules])
- Fix use utils.reduce for IE8 compatibility ([@&#8203;wsw0108])
- Some linting errors fixed by [@&#8203;danielstjules]
- Call the inspect() function if message is not set ([@&#8203;kevinburke])

[#&#8203;1875]: `https://github.com/mochajs/mocha/issues/1875`
[#&#8203;1864]: `https://github.com/mochajs/mocha/issues/1864`
[#&#8203;1846]: `https://github.com/mochajs/mocha/issues/1846`
[#&#8203;1669]: `https://github.com/mochajs/mocha/issues/1669`
[#&#8203;1868]: `https://github.com/mochajs/mocha/issues/1868`
[#&#8203;1766]: `https://github.com/mochajs/mocha/issues/1766`
[#&#8203;1798]: `https://github.com/mochajs/mocha/issues/1798`
[@&#8203;danielstjules]: https://github.com/danielstjules
[@&#8203;wsw0108]: https://github.com/wsw0108
[@&#8203;kevinburke]: https://github.com/kevinburke

---

### [`v2.3.4`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;234--2015-11-15)

- Update debug dependency to 2.2.0
- remove duplication of mocha.opts on process.argv
- Fix typo in test/reporters/nyan.js

---

### [`v2.4.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;241--2016-01-26)

- [#&#8203;2067] - Fix HTML/doc reporter regressions ([@&#8203;danielstjules])

[#&#8203;2067]: `https://github.com/mochajs/mocha/pull/2067`

---

### [`v2.4.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;242--2016-01-26)

- [#&#8203;2053] - Fix web worker compatibility ([@&#8203;mislav])
- [#&#8203;2072] - Fix Windows color output ([@&#8203;thedark1337])
- [#&#8203;2073] - Fix colors in `progress` and `landing` reporters ([@&#8203;gyandeeps])

[#&#8203;2053]: `https://github.com/mochajs/mocha/pull/2053`
[#&#8203;2072]: `https://github.com/mochajs/mocha/pull/2072`
[#&#8203;2073]: `https://github.com/mochajs/mocha/pull/2073`
[@&#8203;gyandeeps]: https://github.com/gyandeeps
[@&#8203;thedark1337]: https://github.com/thedark1337

---

### [`v2.4.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;243--2016-01-27)

- [#&#8203;2078] - Fix broken IE8 ([@&#8203;boneskull])

[#&#8203;2078]: `https://github.com/mochajs/mocha/issues/2078`

---

### [`v2.4.4`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;244--2016-01-27)

- [#&#8203;2080] - Fix broken RequireJS compatibility ([@&#8203;boneskull])

[#&#8203;2080]: `https://github.com/mochajs/mocha/issues/2080`

---

### [`v2.4.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;245--2016-01-28)

- [#&#8203;2080], [#&#8203;2078], [#&#8203;2072], [#&#8203;2073], [#&#8203;1200] - Revert changes to console colors in changeset [1192914](https://github.com/mochajs/mocha/commit/119291449cd03a11cdeda9e37cf718a69a012896) and subsequent related changes thereafter.  Restores compatibility with IE8 & PhantomJS.  See also [mantoni/mochify.js#&#8203;129](`https://github.com/mantoni/mochify.js/issues/129`) and [openlayers/ol3#&#8203;4746](`https://github.com/openlayers/ol3/pull/4746`) ([@&#8203;boneskull])
- [#&#8203;2082] - Fix several test assertions ([@&#8203;mislav])

[#&#8203;1200]: `https://github.com/mochajs/mocha/issues/1200`
[#&#8203;2082]: `https://github.com/mochajs/mocha/pull/2082`

---

### [`v2.5.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;250--2016-05-23)

This has been awhile coming!  We needed to feel confident that the next release wouldn't break browser compatibility (e.g. the last few patch releases).
#### Browser Tests in CI

We now run unit tests against PhantomJS v1.x and an assortment of browsers on [SauceLabs](https://saucelabs.com), including:

- Internet Explorer v8.0
- Chrome (latest)
- Firefox (latest)
- Safari (latest)
- Microsoft Edge (latest)

To accomplish this, we now run Mocha's unit tests (and a handful of integration tests) via [Karma](https://npmjs.com/package/karma) and a modified [karma-mocha](https://npmjs.com/package/karma-mocha).  Along the way, we had to solve issue [#&#8203;880] (apologies to @&#8203;mderijcke and @&#8203;sukima who had PRs addressing this), as well as replace most usages of [should](https://npmjs.com/package/should) with [expect.js](https://npmjs.com/package/expect.js) for IE8.

Going forward, when sending PRs, your code will *only* run against PhantomJS v1.x (and not hit SauceLabs) [because security](https://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).
#### Node.js 6.x

 Node.js 6.x "just worked" before, but now it's in the CI matrix, so it's "officially" supported.  Mocha *still retains support* for Node.js 0.8.x.
#### "Minor" Release

You'll see mostly bug fixes below, but also a couple features--as such, it's a "minor" release.
#### TYVM

Thanks to everyone who contributed, and our fabulous [sponsors and backers](https://opencollective.com/mochajs)!

- [#&#8203;2079] - Add browser checks to CI; update [browserify](https://npmjs.com/package/browserify) to v13.0.0 ([@&#8203;dasilvacontin], [@&#8203;ScottFreeCode], [@&#8203;boneskull] via c04c1d7, 0b1e9b3, 0dde0fa, f8a3d86, 9e8cbaa)
- [#&#8203;880] - Make Mocha browserifyable ([@&#8203;boneskull] via 524862b)
- [#&#8203;2121] - Update [glob](https://npmjs.com/package/glob) to v3.2.11 ([@&#8203;astorije] via 7920fc4)
- [#&#8203;2126] - Fix dupe error messages in stack trace filter ([@&#8203;Turbo87] via 4301caa)
- [#&#8203;2109] - Fix certain diffs when objects cannot be coerced into primitives ([@&#8203;joshlory] via 61fbb7f)
- [#&#8203;1827] - Fix TWBS/`mocha.css` collisions ([@&#8203;irnc] via 0543798)
- [#&#8203;1760], [#&#8203;1936] - Fix `this.skip()` in HTML reporter ([@&#8203;mislav] via cb4248b)
- [#&#8203;2115] - Fix exceptions thrown from hooks in HTML reporter ([@&#8203;danielstjules] via e290bc0)
- [#&#8203;2089] - Handle Symbol values in `util.stringify()` ([@&#8203;ryym] via ea61d05)
- [#&#8203;2097] - Fix diff for objects overriding `Object.prototype.hasOwnProperty` ([@&#8203;mantoni] via b20fdfe)
- [#&#8203;2101] - Properly handle non-string "messages" thrown from assertion libraries ([@&#8203;jkimbo] via 9c41051)
- [#&#8203;2124] - Update [growl](https://npmjs.com/package/growl) ([@&#8203;benjamine] via 9ae6a85)
- [#&#8203;2162], [#&#8203;2205] - JSDoc fixes ([@&#8203;OlegTsyba] via 8031f20, [@&#8203;ScottFreeCode] via f83b1d9)
- [#&#8203;2132] - Remove Growl-related cruft ([@&#8203;julienw] via 00d6469)
- [#&#8203;2172] - Add [OpenCollective](https://opencollective.com) badge, sponsors & backers ([@&#8203;xdamman], [@&#8203;boneskull] via caee94f)
- [#&#8203;1841] - Add new logo, banner assets ([@&#8203;dasilvacontin] via 00fd0e1)
- [#&#8203;2214] - Update `README.md` header ([@&#8203;dasilvacontin] via c0f9be2)
- [#&#8203;2236] - Better checks for Node.js v0.8 compatibility in CI ([@&#8203;dasilvacontin] via ba5637d)
- [#&#8203;2239] - Add Node.js v6.x to CI matrix ([@&#8203;boneskull] via 3904da4)

[#&#8203;880]: `https://github.com/mochajs/mocha/issues/880`
[#&#8203;1841]: `https://github.com/mochajs/mocha/pull/1841`
[#&#8203;2239]: `https://github.com/mochajs/mocha/issues/2239`
[#&#8203;2153]: `https://github.com/mochajs/mocha/pull/2153`
[#&#8203;2214]: `https://github.com/mochajs/mocha/pull/2214`
[#&#8203;2236]: `https://github.com/mochajs/mocha/pull/2236`
[#&#8203;2079]: `https://github.com/mochajs/mocha/issues/2079`
[#&#8203;2231]: `https://github.com/mochajs/mocha/pull/2231`
[#&#8203;2089]: `https://github.com/mochajs/mocha/issues/2089`
[#&#8203;2097]: `https://github.com/mochajs/mocha/pull/2097`
[#&#8203;1760]: `https://github.com/mochajs/mocha/issues/1760`
[#&#8203;1936]: `https://github.com/mochajs/mocha/issues/1936`
[#&#8203;2115]: `https://github.com/mochajs/mocha/pull/2115`
[#&#8203;1827]: `https://github.com/mochajs/mocha/pull/1827`
[#&#8203;2101]: `https://github.com/mochajs/mocha/pull/2101`
[#&#8203;2124]: `https://github.com/mochajs/mocha/pull/2124`
[#&#8203;2109]: `https://github.com/mochajs/mocha/issues/2109`
[#&#8203;2162]: `https://github.com/mochajs/mocha/pull/2162`
[#&#8203;2132]: `https://github.com/mochajs/mocha/issues/2132`
[#&#8203;2126]: `https://github.com/mochajs/mocha/issues/2126`
[#&#8203;2121]: `https://github.com/mochajs/mocha/issues/2121`
[#&#8203;2205]: `https://github.com/mochajs/mocha/pull/2205`
[#&#8203;2172]: `https://github.com/mochajs/mocha/pull/2172`
[@&#8203;xdamman]: https://github.com/xdamman
[@&#8203;Turbo87]: https://github.com/Turbo87
[@&#8203;OlegTsyba]: https://github.com/OlegTsyba
[@&#8203;ryym]: https://github.com/ryym
[@&#8203;mantoni]: https://github.com/mantoni
[@&#8203;mislav]: https://github.com/mislav
[@&#8203;irnc]: https://github.com/irnc
[@&#8203;jkimbo]: https://github.com/jkimbo
[@&#8203;benjamine]: https://github.com/benjamine
[@&#8203;joshlory]: https://github.com/joshlory
[@&#8203;julienw]: https://github.com/julienw
[@&#8203;ScottFreeCode]: https://github.com/ScottFreeCode
[@&#8203;astorije]: https://github.com/astorije
[@&#8203;dasilvacontin]: https://github.com/dasilvacontin

---

### [`v2.5.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;251--2016-05-23)

- Fix [to-iso-string](https://npmjs.com/package/to-iso-string) dependency ([@&#8203;boneskull] via bd9450b)

Thanks @&#8203;entertainyou, @&#8203;SimenB, @&#8203;just-paja for the heads-up.

---

### [`v2.5.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;252--2016-05-24)

- [#&#8203;2178] - Avoid double and triple xUnit XML escaping ([@&#8203;graingert] via 49b5ff1)

[@&#8203;graingert]: https://github.com/graingert
[#&#8203;2178]: `https://github.com/mochajs/mocha/pull/2178`

---

### [`v2.5.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;253--2016-05-25)

- [#&#8203;2112] - Fix HTML reporter regression causing duplicate error output ([@&#8203;danielstjules] via 6d24063)
- [#&#8203;2119] - Make HTML reporter failure/passed links preventDefault to avoid SPA's hash navigation ([@&#8203;jimenglish81] via 9e93efc)

[@&#8203;danielstjules]: https://github.com/danielstjules
[@&#8203;jimenglish81]: https://github.com/jimenglish81
[#&#8203;2112]: `https://github.com/mochajs/mocha/pull/2112`
[#&#8203;2119]: `https://github.com/mochajs/mocha/pull/2119`

---

### [`v3.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;300--2016-07-31)

#### :boom: Breaking Changes

- :warning: Due to the increasing difficulty of applying security patches made within its dependency tree, as well as looming incompatibilities with Node.js v7.0, **Mocha no longer supports Node.js v0.8**.
- :warning: **Mocha may no longer be installed by versions of `npm` less than `1.4.0`.**  Previously, this requirement only affected Mocha's development dependencies.  In short, this allows Mocha to depend on packages which have dependencies fixed to major versions (`^`).
- `.only()` is no longer "fuzzy", can be used multiple times, and generally just works like you think it should. :joy:
- To avoid common bugs, when a test injects a callback function (suggesting asynchronous execution), calls it, *and* returns a `Promise`, Mocha will now throw an exception:

  ```js
  const assert = require('assert');

  it('should complete this test', function (done) {
    return new Promise(function (resolve) {
      assert.ok(true);
      resolve();
    })
      .then(done);
  });
  ```

  The above test will fail with `Error: Resolution method is overspecified. Specify a callback *or* return a Promise; not both.`.
- When a test timeout value *greater than* `2147483648` is specified in any context (`--timeout`, `mocha.setup()`, per-suite, per-test, etc.), the timeout will be *disabled* and the test(s) will be allowed to run indefinitely.  This is equivalent to specifying a timeout value of `0`.  See [MDN](https://developer.mozilla.org/docs/Web/API/WindowTimers/setTimeout#Maximum_delay_value) for reasoning.
- The `dot` reporter now uses more visually distinctive characters when indicating "pending" and "failed" tests.
- Mocha no longer supports [component](https://www.npmjs.com/package/component).
- The long-forsaken `HTMLCov` and `JSONCov` reporters--and any relationship to the "node-jscoverage" project--have been removed.
- `spec` reporter now omits leading carriage returns (`\r`) in non-TTY environment.
#### :tada: Enhancements

- [#&#8203;808]: Allow regular-expression-like strings in `--grep` and browser's `grep` querystring; enables flags such as `i` for case-insensitive matches and `u` for unicode. ([@&#8203;a8m])
- [#&#8203;2000]: Use distinctive characters in `dot` reporter; `,` will denote a "pending" test and `!` will denote a "failing" test. ([@&#8203;elliottcable])
- [#&#8203;1632]: Throw a useful exception when a suite or test lacks a title. ([@&#8203;a8m])
- [#&#8203;1481]: Better `.only()` behavior. ([@&#8203;a8m])
- [#&#8203;2334]: Allow `this.skip()` in async tests and hooks. ([@&#8203;boneskull])
- [#&#8203;1320]: Throw a useful exception when test resolution method is overspecified. ([@&#8203;jugglinmike])
- [#&#8203;2364]: Support `--preserve-symlinks`. ([@&#8203;rosswarren])
#### :bug: Bug Fixes

- [#&#8203;2259]: Restore ES3 compatibility.  Specifically, support an environment lacking `Date.prototype.toISOString()`, `JSON`, or has a non-standard implementation of `JSON`. ([@&#8203;ndhoule], [@&#8203;boneskull])
- [#&#8203;2286]: Fix `after()` failing to execute if test skipped using `this.skip()` in `beforeEach()`; no longer marks the entire suite as "pending". ([@&#8203;dasilvacontin], [@&#8203;boneskull])
- [#&#8203;2208]: Fix function name display in `markdown` and `html` (browser) reporters. ([@&#8203;ScottFreeCode])
- [#&#8203;2299]: Fix progress bar in `html` (browser) reporter. ([@&#8203;AviVahl])
- [#&#8203;2307]: Fix `doc` reporter crashing when test fails. ([@&#8203;jleyba])
- [#&#8203;2323]: Ensure browser entry point (`browser-entry.js`) is published to npm (for use with bundlers).  ([@&#8203;boneskull])
- [#&#8203;2310]: Ensure custom reporter with an absolute path works in Windows. ([@&#8203;silentcloud])
- [#&#8203;2311]: Fix problem wherein calling `this.slow()` without a value would blast any previously set value. ([@&#8203;boneskull])
- [#&#8203;1813]: Ensure Mocha's own test suite will run in Windows. ([@&#8203;tswaters], [@&#8203;TimothyGu], [@&#8203;boneskull])
- [#&#8203;2317]: Ensure all interfaces are displayed in `--help` on CLI.  ([@&#8203;ScottFreeCode])
- [#&#8203;1644]: Don't exhibit undefined behavior when calling `this.timeout()` with very large values ([@&#8203;callumacrae], [@&#8203;boneskull])
- [#&#8203;2361]: Don't truncate name of thrown anonymous exception. ([@&#8203;boneskull])
- [#&#8203;2367]: Fix invalid CSS. ([@&#8203;bensontrent])
- [#&#8203;2401]: Remove carriage return before each test line in spec reporter. ([@&#8203;Munter])
#### :nut_and_bolt: Other

- Upgrade production dependencies to address security advisories (and because now we can): `glob`, `commander`, `escape-string-regexp`, and `supports-color`. ([@&#8203;boneskull], [@&#8203;RobLoach])
- Add Windows to CI. ([@&#8203;boneskull], [@&#8203;TimothyGu])
- Ensure appropriate `engines` field in `package.json`. ([@&#8203;shinnn], [@&#8203;boneskull])
- [#&#8203;2348]: Upgrade ESLint to v2 ([@&#8203;anthony-redfox])

We :heart: our [backers and sponsors](https://opencollective.com/mochajs)!

:shipit:

[#&#8203;2401]: `https://github.com/mochajs/mocha/pull/2401`
[#&#8203;2348]: `https://github.com/mochajs/mocha/issues/2348`
[#&#8203;808]: `https://github.com/mochajs/mocha/issues/808`
[#&#8203;2361]: `https://github.com/mochajs/mocha/pull/2361`
[#&#8203;2367]: `https://github.com/mochajs/mocha/pull/2367`
[#&#8203;2364]: `https://github.com/mochajs/mocha/pull/2364`
[#&#8203;1320]: `https://github.com/mochajs/mocha/pull/1320`
[#&#8203;2307]: `https://github.com/mochajs/mocha/pull/2307`
[#&#8203;2259]: `https://github.com/mochajs/mocha/pull/2259`
[#&#8203;2208]: `https://github.com/mochajs/mocha/pull/2208`
[#&#8203;2299]: `https://github.com/mochajs/mocha/pull/2299`
[#&#8203;2286]: `https://github.com/mochajs/mocha/issues/2286`
[#&#8203;1644]: `https://github.com/mochajs/mocha/issues/1644`
[#&#8203;2310]: `https://github.com/mochajs/mocha/issues/2310`
[#&#8203;2311]: `https://github.com/mochajs/mocha/issues/2311`
[#&#8203;2323]: `https://github.com/mochajs/mocha/issues/2323`
[#&#8203;2000]: `https://github.com/mochajs/mocha/pull/2000`
[#&#8203;1632]: `https://github.com/mochajs/mocha/issues/1632`
[#&#8203;1813]: `https://github.com/mochajs/mocha/issues/1813`
[#&#8203;2334]: `https://github.com/mochajs/mocha/issues/2334`
[#&#8203;2317]: `https://github.com/mochajs/mocha/issues/2317`
[#&#8203;1481]: `https://github.com/mochajs/mocha/issues/1481`
[@&#8203;elliottcable]: https://github.com/elliottcable
[@&#8203;RobLoach]: https://github.com/robloach
[@&#8203;AviVahl]: https://github.com/avivahl
[@&#8203;silentcloud]: https://github.com/silentcloud
[@&#8203;tswaters]: https://github.com/tswaters
[@&#8203;jleyba]: https://github.com/jleyba
[@&#8203;TimothyGu]: https://github.com/timothygu
[@&#8203;callumacrae]: https://github.com/callumacrae
[@&#8203;shinnn]: https://github.com/shinnn
[@&#8203;bensontrent]: https://github.com/bensontrent
[@&#8203;jugglinmike]: https://github.com/jugglinmike
[@&#8203;rosswarren]: https://github.com/rosswarren
[@&#8203;anthony-redfox]: https://github.com/anthony-redfox
[@&#8203;Munter]: https://github.com/munter

---

### [`v3.0.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;301--2016-08-03)

#### :bug: Bug Fix

- [#&#8203;2406]: Restore execution of nested `describe.only()` suites ([@&#8203;not-an-aardvark])

[#&#8203;2406]: `https://github.com/mochajs/mocha/issues/2406`
[@&#8203;not-an-aardvark]: https://github.com/not-an-aardvark

---

### [`v3.0.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;302--2016-08-08)

#### :bug: Bug Fix

- [#&#8203;2424]: Fix error loading Mocha via Require.js ([@&#8203;boneskull])
- [#&#8203;2417]: Fix execution of *deeply* nested `describe.only()` suites ([@&#8203;not-an-aardvark])
- Remove references to `json-cov` and `html-cov` reporters in CLI ([@&#8203;boneskull])

[#&#8203;2417]: `https://github.com/mochajs/mocha/issues/2417`
[#&#8203;2424]: `https://github.com/mochajs/mocha/issues/2424`

---

### [`v3.1.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;310--2016-09-27)

#### :tada: Enhancement

- [#&#8203;2357]: Support `--inspect` on command-line ([@&#8203;simov])
- [#&#8203;2194]: Human-friendly error if no files are matched on command-line ([@&#8203;Munter])
- [#&#8203;1744]: Human-friendly error if a Suite has no callback (BDD/TDD only) ([@&#8203;anton])
#### :bug: Bug Fix

- [#&#8203;2488]: Fix case in which *variables beginning with lowercase "D"* may not have been reported properly as global leaks ([@&#8203;JustATrick]) :laughing:
- [#&#8203;2465]: Always halt execution in async function when `this.skip()` is called ([@&#8203;boneskull])
- [#&#8203;2445]: Exits with expected code 130 when `SIGINT` encountered; exit code can no longer rollover at 256 ([@&#8203;Munter])
- [#&#8203;2315]: Fix uncaught TypeError thrown from callback stack ([@&#8203;1999])
- Fix broken `only()`/`skip()` in IE7/IE8 ([@&#8203;boneskull])
- [#&#8203;2502]: Fix broken stack trace filter on Node.js under Windows ([@&#8203;boneskull])
- [#&#8203;2496]: Fix diff output for objects instantiated with `String` constructor ([more](https://youtrack.jetbrains.com/issue/WEB-23383)) ([@&#8203;boneskull])

[#&#8203;2496]: `https://github.com/mochajs/mocha/issues/2496`
[#&#8203;2502]: `https://github.com/mochajs/mocha/issues/2502`
[#&#8203;2315]: `https://github.com/mochajs/mocha/issues/2315`
[#&#8203;2445]: `https://github.com/mochajs/mocha/pull/2445`
[#&#8203;2465]: `https://github.com/mochajs/mocha/issues/2465`
[#&#8203;2488]: `https://github.com/mochajs/mocha/issues/2488`
[#&#8203;1744]: `https://github.com/mochajs/mocha/issues/1744`
[#&#8203;2194]: `https://github.com/mochajs/mocha/issues/2194`
[#&#8203;2357]: `https://github.com/mochajs/mocha/issues/2357`
[@&#8203;1999]: https://github.com/1999
[@&#8203;JustATrick]: https://github.com/JustATrick
[@&#8203;anton]: https://github.com/anton
[@&#8203;simov]: https://github.com/simov

---

### [`v3.1.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;311--2016-10-09)

#### :bug: Bug Fix

- [#&#8203;1417]: Don't report `done()` was called multiple times when it wasn't ([@&#8203;frankleonrose])
#### :nut_and_bolt: Other

- [#&#8203;2490]: Lint with [semistandard](https://npmjs.com/package/semistandard) config ([@&#8203;makepanic])
- [#&#8203;2525]: Lint all `.js` files ([@&#8203;boneskull])
- [#&#8203;2524]: Provide workaround for developers unable to run browser tests on macOS Sierra ([@&#8203;boneskull])

[#&#8203;1417]: `https://github.com/mochajs/mocha/issues/1417`
[#&#8203;2490]: `https://github.com/mochajs/mocha/issues/2490`
[#&#8203;2525]: `https://github.com/mochajs/mocha/issues/2525`
[#&#8203;2524]: `https://github.com/mochajs/mocha/issues/2524`
[@&#8203;makepanic]: https://github.com/makepanic
[@&#8203;frankleonrose]: https://github.com/frankleonrose

---

### [`v3.1.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;312--2016-10-10)

#### :bug: Bug Fix

- [#&#8203;2528]: Recovery gracefully if an `Error`'s `stack` property isn't writable ([@&#8203;boneskull])

[#&#8203;2528]: `https://github.com/mochajs/mocha/issues/2528`

---

### [`v3.2.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;320--2016-11-24)

#### :newspaper: News
##### Mocha is now a JS Foundation Project!

Mocha is proud to have joined the [JS Foundation](https://js.foundation).  For more information, [read the announcement](https://js.foundation/announcements/2016/10/17/Linux-Foundation-Unites-JavaScript-Community-Open-Web-Development/).
##### Contributor License Agreement

Under the foundation, all contributors to Mocha must sign the [JS Foundation CLA](https://js.foundation/CLA/) before their code can be merged.  When sending a PR--if you have not already signed the CLA--a friendly bot will ask you to do so.

Mocha remains licensed under the [MIT license](https://github.com/mochajs/mocha/blob/master/LICENSE).
#### :bug: Bug Fix

- [#&#8203;2535]: Fix crash when `--watch` encounters broken symlinks ([@&#8203;villesau])
- [#&#8203;2593]: Fix (old) regression; incorrect symbol shown in `list` reporter ([@&#8203;Aldaviva])
- [#&#8203;2584]: Fix potential error when running XUnit reporter ([@&#8203;vobujs])
#### :tada: Enhancement

- [#&#8203;2294]: Improve timeout error messaging ([@&#8203;jeversmann], [@&#8203;boneskull])
- [#&#8203;2520]: Add info about `--inspect` flag to CLI help ([@&#8203;ughitsaaron])
#### :nut_and_bolt: Other

- [#&#8203;2570]: Use [karma-mocha](https://npmjs.com/package/karma-mocha) proper ([@&#8203;boneskull])
- Licenses updated to reflect new copyright, add link to license and browser matrix to `README.md` ([@&#8203;boneskull], [@&#8203;ScottFreeCode], [@&#8203;dasilvacontin])

[#&#8203;2294]: `https://github.com/mochajs/mocha/issues/2294`
[#&#8203;2535]: `https://github.com/mochajs/mocha/issues/2535`
[#&#8203;2520]: `https://github.com/mochajs/mocha/pull/2520`
[#&#8203;2593]: `https://github.com/mochajs/mocha/pull/2593`
[#&#8203;2584]: `https://github.com/mochajs/mocha/issues/2584`
[#&#8203;2570]: `https://github.com/mochajs/mocha/issues/2570`
[@&#8203;Aldaviva]: https://github.com/Aldaviva
[@&#8203;jeversmann]: https://github.com/jeversmann
[@&#8203;ughitsaaron]: https://github.com/ughitsaaron
[@&#8203;villesau]: https://github.com/villesau
[@&#8203;vobujs]: https://github.com/vobujs

Thanks to all our contributors, sponsors and backers!  Keep on the lookout for a public roadmap and new contribution guide coming soon.

---

### [`v3.3.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;330--2017-04-24)

Thanks to all our contributors, maintainers, sponsors, and users! ❤️

As highlights:

- We've got coverage now!
- Testing is looking less flaky \o/.
- No more nitpicking about "mocha.js" build on PRs.
#### :tada: Enhancements

- [#&#8203;2659]: Adds support for loading reporter from an absolute or relative path ([@&#8203;sul4bh])
- [#&#8203;2769]: Support `--inspect-brk` on command-line ([@&#8203;igwejk])
#### :bug: Fixes

- [#&#8203;2662]: Replace unicode chars w/ hex codes in HTML reporter ([@&#8203;rotemdan])
#### :mag: Coverage

- [#&#8203;2672]: Add coverage for node tests ([@&#8203;c089], [@&#8203;Munter])
- [#&#8203;2680]: Increase tests coverage for base reporter ([@&#8203;epallerols])
- [#&#8203;2690]: Increase tests coverage for doc reporter ([@&#8203;craigtaub])
- [#&#8203;2701]: Increase tests coverage for landing, min, tap and list reporters ([@&#8203;craigtaub])
- [#&#8203;2691]: Increase tests coverage for spec + dot reporters ([@&#8203;craigtaub])
- [#&#8203;2698]: Increase tests coverage for xunit reporter ([@&#8203;craigtaub])
- [#&#8203;2699]: Increase tests coverage for json-stream, markdown and progress reporters ([@&#8203;craigtaub])
- [#&#8203;2703]: Cover .some() function in utils.js with tests ([@&#8203;seppevs])
- [#&#8203;2773]: Add tests for loading reporters w/ relative/absolute paths ([@&#8203;sul4bh])
#### :nut_and_bolt: Other

- Remove bin/.eslintrc; ensure execs are linted ([@&#8203;boneskull])
- [#&#8203;2542]: Expand CONTRIBUTING.md ([@&#8203;boneskull])
- [#&#8203;2660]: Double timeouts on integration tests ([@&#8203;Munter])
- [#&#8203;2653]: Update copyright year ([@&#8203;Scottkao85], [@&#8203;Munter])
- [#&#8203;2621]: Update dependencies to enable Greenkeeper ([@&#8203;boneskull], [@&#8203;greenkeeper])
- [#&#8203;2625]: Use trusty container in travis-ci; use "artifacts" addon ([@&#8203;boneskull])
- [#&#8203;2670]: doc(CONTRIBUTING): fix link to org members ([@&#8203;coderbyheart])
- Add Mocha propaganda to README.md ([@&#8203;boneskull])
- [#&#8203;2470]: Avoid test flake in "delay" test ([@&#8203;boneskull])
- [#&#8203;2675]: Limit browser concurrency on sauce ([@&#8203;boneskull])
- [#&#8203;2669]: Use temporary test-only build of mocha.js for browsers tests ([@&#8203;Munter])
- Fix "projects" link in README.md ([@&#8203;boneskull])
- [#&#8203;2678]: Chore(Saucelabs): test on IE9, IE10 and IE11 ([@&#8203;coderbyheart])
- [#&#8203;2648]: Use `semistandard` directly ([@&#8203;kt3k])
- [#&#8203;2727]: Make the build reproducible ([@&#8203;lamby])

[@&#8203;boneskull]: https://github.com/boneskull
[@&#8203;c089]: https://github.com/c089
[@&#8203;coderbyheart]: https://github.com/coderbyheart
[@&#8203;craigtaub]: https://github.com/craigtaub
[@&#8203;epallerols]: https://github.com/epallerols
[@&#8203;greenkeeper]: https://github.com/greenkeeper
[@&#8203;igwejk]: https://github.com/igwejk
[@&#8203;kt3k]: https://github.com/kt3k
[@&#8203;lamby]: https://github.com/lamby
[@&#8203;Munter]: https://github.com/Munter
[@&#8203;rotemdan]: https://github.com/rotemdan
[@&#8203;seppevs]: https://github.com/seppevs
[@&#8203;sul4bh]: https://github.com/sul4bh

[#&#8203;2470]: `https://github.com/mochajs/mocha/pull/2470`
[#&#8203;2542]: `https://github.com/mochajs/mocha/issues/2542`
[#&#8203;2621]: `https://github.com/mochajs/mocha/pull/2621`
[#&#8203;2625]: `https://github.com/mochajs/mocha/pull/2625`
[#&#8203;2648]: `https://github.com/mochajs/mocha/pull/2648`
[#&#8203;2653]: `https://github.com/mochajs/mocha/pull/2653`
[#&#8203;2659]: `https://github.com/mochajs/mocha/pull/2659`
[#&#8203;2660]: `https://github.com/mochajs/mocha/pull/2660`
[#&#8203;2662]: `https://github.com/mochajs/mocha/pull/2662`
[#&#8203;2669]: `https://github.com/mochajs/mocha/pull/2669`
[#&#8203;2670]: `https://github.com/mochajs/mocha/pull/2670`
[#&#8203;2672]: `https://github.com/mochajs/mocha/pull/2672`
[#&#8203;2675]: `https://github.com/mochajs/mocha/pull/2675`
[#&#8203;2678]: `https://github.com/mochajs/mocha/pull/2678`
[#&#8203;2680]: `https://github.com/mochajs/mocha/pull/2680`
[#&#8203;2690]: `https://github.com/mochajs/mocha/pull/2690`
[#&#8203;2691]: `https://github.com/mochajs/mocha/pull/2691`
[#&#8203;2698]: `https://github.com/mochajs/mocha/pull/2698`
[#&#8203;2699]: `https://github.com/mochajs/mocha/pull/2699`
[#&#8203;2701]: `https://github.com/mochajs/mocha/pull/2701`
[#&#8203;2703]: `https://github.com/mochajs/mocha/pull/2703`
[#&#8203;2727]: `https://github.com/mochajs/mocha/pull/2727`
[#&#8203;2769]: `https://github.com/mochajs/mocha/pull/2769`
[#&#8203;2773]: `https://github.com/mochajs/mocha/pull/2773`

---

### [`v3.4.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;340--2017-05-14)

Mocha is now moving to a quicker release schedule: when non-breaking changes are merged, a release should happen that week.

This week's highlights:

- `allowUncaught` added to commandline as `--allow-uncaught` (and bugfixed)
- warning-related Node flags
#### :tada: Enhancements

- [#&#8203;2793], [#&#8203;2697]: add --allowUncaught to Node.js ([@&#8203;lrowe])
- [#&#8203;2733]: Add `--no-warnings` and `--trace-warnings` flags ([@&#8203;sonicdoe])
#### :bug: Fixes

- [#&#8203;2793], [#&#8203;2697]: fix broken allowUncaught ([@&#8203;lrowe])
#### :nut_and_bolt: Other

- [#&#8203;2778]: Add license report and scan status ([@&#8203;xizhao])
- [#&#8203;2794]: no special case for macOS running Karma locally ([@&#8203;boneskull])
- [#&#8203;2795]: reverts use of semistandard directly ([#&#8203;2648]) ([@&#8203;boneskull])

[@&#8203;lrowe]: https://github.com/lrowe
[@&#8203;sonicdoe]: https://github.com/sonicdoe
[@&#8203;xizhao]: https://github.com/xizhao
[@&#8203;boneskull]: https://github.com/boneskull

[#&#8203;2795]: `https://github.com/mochajs/mocha/pull/2795`
[#&#8203;2733]: `https://github.com/mochajs/mocha/pull/2733`
[#&#8203;2793]: `https://github.com/mochajs/mocha/pull/2793`
[#&#8203;2697]: `https://github.com/mochajs/mocha/pull/2697`
[#&#8203;2778]: `https://github.com/mochajs/mocha/pull/2778`
[#&#8203;2794]: `https://github.com/mochajs/mocha/pull/2794`

---

### [`v3.4.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;341--2017-05-14)

Fixed a publishing mishap with git's autocrlf settings.

---

### [`v3.4.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;342--2017-05-24)

#### :bug: Fixes

- [#&#8203;2802]: Remove call to deprecated `os.tmpDir` ([@&#8203;makepanic])
- [#&#8203;2820]: Eagerly set `process.exitCode` ([@&#8203;chrisleck])
#### :nut_and_bolt: Other

- [#&#8203;2778]: Move linting into an npm script ([@&#8203;Munter])

[@&#8203;chrisleck]: https://github.com/chrisleck
[@&#8203;makepanic]: https://github.com/makepanic
[@&#8203;Munter]: https://github.com/Munter

[#&#8203;2778]: `https://github.com/mochajs/mocha/pull/2778`
[#&#8203;2802]: `https://github.com/mochajs/mocha/issues/2802`
[#&#8203;2820]: `https://github.com/mochajs/mocha/pull/2820`

---

### [`v3.5.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;350--2017-07-31)

#### :newspaper: News

- Mocha now has a [code of conduct](https://github.com/mochajs/mocha/blob/master/.github/CODE_OF_CONDUCT.md) (thanks [@&#8203;kungapal]!).
- Old issues and PRs are now being marked "stale" by [Probot's "Stale" plugin](https://github.com/probot/stale).  If an issue is marked as such, and you would like to see it remain open, simply add a new comment to the ticket or PR.
- **WARNING**: Support for non-ES5-compliant environments will be dropped starting with version 4.0.0 of Mocha!
#### :lock: Security Fixes

- [#&#8203;2860]: Address [CVE-2015-8315](https://nodesecurity.io/advisories/46) via upgrade of [debug](https://npm.im/debug) ([@&#8203;boneskull])
#### :tada: Enhancements

- [#&#8203;2696]: Add `--forbid-only` and `--forbid-pending` flags.  Use these in CI or hooks to ensure tests aren't accidentally being skipped! ([@&#8203;charlierudolph])
- [#&#8203;2813]: Support Node.js 8's `--napi-modules` flag ([@&#8203;jupp0r])
#### :nut_and_bolt: Other

- Various CI-and-test-related fixes and improvements ([@&#8203;boneskull], [@&#8203;dasilvacontin], [@&#8203;PopradiArpad], [@&#8203;Munter], [@&#8203;ScottFreeCode])
- "Officially" support Node.js 8 ([@&#8203;elergy])

[#&#8203;2860]: `https://github.com/mochajs/mocha/pull/2860`
[#&#8203;2696]: `https://github.com/mochajs/mocha/pull/2696`
[#&#8203;2813]: `https://github.com/mochajs/mocha/pull/2813`
[@&#8203;charlierudolph]: https://github.com/charlierudolph
[@&#8203;PopradiArpad]: https://github.com/PopradiArpad
[@&#8203;kungapal]: https://github.com/kungapal
[@&#8203;elergy]: https://github.com/elergy
[@&#8203;jupp0r]: https://github.com/jupp0r

---

### [`v3.5.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;351--2017-09-09)

#### :newspaper: News

- :mega: Mocha is now sponsoring [PDXNode](http://pdxnode.org)!  If you're in the [Portland](https://wikipedia.org/wiki/Portland,_Oregon) area, come check out the monthly talks and hack nights!
#### :bug: Fixes

- [#&#8203;2997]: Fix missing `xit` export for "require" interface ([@&#8203;solodynamo])
- [#&#8203;2957]: Fix unicode character handling in XUnit reporter failures ([@&#8203;jkrems])
#### :nut_and_bolt: Other

- [#&#8203;2986]: Add issue and PR templates ([@&#8203;kungapal])
- [#&#8203;2918]: Drop bash dependency for glob-related tests ([@&#8203;ScottFreeCode])
- [#&#8203;2922]: Improve `--compilers` coverage ([@&#8203;ScottFreeCode])
- [#&#8203;2981]: Fix tpyos and spelling errors ([@&#8203;jsoref])

[#&#8203;2997]: `https://github.com/mochajs/mocha/pull/2997`
[#&#8203;2957]: `https://github.com/mochajs/mocha/pull/2957`
[#&#8203;2918]: `https://github.com/mochajs/mocha/pull/2918`
[#&#8203;2986]: `https://github.com/mochajs/mocha/pull/2986`
[#&#8203;2922]: `https://github.com/mochajs/mocha/pull/2922`
[#&#8203;2981]: `https://github.com/mochajs/mocha/pull/2981`
[@&#8203;solodynamo]: https://github.com/solodynamo
[@&#8203;jkrems]: https://github.com/jkrems
[@&#8203;jsoref]: https://github.com/jsoref

---

### [`v3.5.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;352--2017-09-10)

#### :bug: Fixes

- [#&#8203;3001]: Fix AMD-related failures first appearing in v3.5.1 ([@&#8203;boneskull])

[#&#8203;3001]: `https://github.com/mochajs/mocha/pull/3001`

---

### [`v3.5.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;353--2017-09-11)

#### :bug: Fixes

- [#&#8203;3003]: Fix invalid entities in xUnit reporter first appearing in v3.5.1 ([@&#8203;jkrems])

[#&#8203;3003]: `https://github.com/mochajs/mocha/pull/3003`

---

### [`v4.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;400--2017-10-02)

You might want to read this before filing a new bug!  :stuck_out_tongue_closed_eyes:
#### :boom: Breaking Changes

For more info, please [read this article](https://boneskull.com/mocha-v4-nears-release/).
##### Compatibility

- [#&#8203;3016]: Drop support for unmaintained versions of Node.js ([@&#8203;boneskull]):
  - 0.10.x
  - 0.11.x
  - 0.12.x
  - iojs (any)
  - 5.x.x
- [#&#8203;2979]: Drop support for non-ES5-compliant browsers ([@&#8203;boneskull]):
  - IE7
  - IE8
  - PhantomJS 1.x
- [#&#8203;2615]: Drop Bower support; old versions (3.x, etc.) will remain available ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
##### Default Behavior

- [#&#8203;2879]: By default, Mocha will no longer force the process to exit once all tests complete.  This means any test code (or code under test) which would normally prevent `node` from exiting will do so when run in Mocha.  Supply the `--exit` flag to revert to pre-v4.0.0 behavior ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
##### Reporter Output

- [#&#8203;2095]: Remove `stdout:` prefix from browser reporter logs ([@&#8203;skeggse])
- [#&#8203;2295]: Add separator in "unified diff" output ([@&#8203;olsonpm])
- [#&#8203;2686]: Print failure message when `--forbid-pending` or `--forbid-only` is specified ([@&#8203;ScottFreeCode])
- [#&#8203;2814]: Indent contexts for better readability when reporting failures ([@&#8203;charlierudolph])
#### :-1: Deprecations

- [#&#8203;2493]: The `--compilers` command-line option is now soft-deprecated and will emit a warning on `STDERR`.  Read [this](https://github.com/mochajs/mocha/wiki/compilers-deprecation) for more info and workarounds ([@&#8203;ScottFreeCode], [@&#8203;boneskull])
#### :tada: Enhancements

- [#&#8203;2628]: Allow override of default test suite name in XUnit reporter ([@&#8203;ngeor])
#### :book: Documentation

- [#&#8203;3020]: Link to CLA in `README.md` and `CONTRIBUTING.md` ([@&#8203;skeggse])
#### :nut_and_bolt: Other

- [#&#8203;2890]: Speed up build by (re-)consolidating SauceLabs tests ([@&#8203;boneskull])

[#&#8203;3016]: `https://github.com/mochajs/mocha/issues/3016`
[#&#8203;2979]: `https://github.com/mochajs/mocha/issues/2979`
[#&#8203;2615]: `https://github.com/mochajs/mocha/issues/2615`
[#&#8203;2879]: `https://github.com/mochajs/mocha/issues/2879`
[#&#8203;2095]: `https://github.com/mochajs/mocha/issues/2095`
[#&#8203;2295]: `https://github.com/mochajs/mocha/issues/2295`
[#&#8203;2686]: `https://github.com/mochajs/mocha/issues/2686`
[#&#8203;2814]: `https://github.com/mochajs/mocha/pull/2814`
[#&#8203;2493]: `https://github.com/mochajs/mocha/issues/2493`
[#&#8203;2628]: `https://github.com/mochajs/mocha/issues/2628`
[#&#8203;3020]: `https://github.com/mochajs/mocha/pull/3020`
[#&#8203;2890]: `https://github.com/mochajs/mocha/issues/2890`
[@&#8203;skeggse]: https://github.com/skeggse
[@&#8203;olsonpm]: https://github.com/olsonpm
[@&#8203;ngeor]: https://github.com/ngeor

---

### [`v4.0.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;401--2017-10-05)

#### :bug: Fixes

- [#&#8203;3051]: Upgrade Growl to v1.10.3 to fix its [peer dep problems](`https://github.com/tj/node-growl/pull/68`) ([@&#8203;dpogue])

[#&#8203;3051]: `https://github.com/mochajs/mocha/pull/3051`
[@&#8203;dpogue]: https://github.com/dpogue

---

### [`v4.1.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;410--2017-12-28)

This is mainly a "housekeeping" release.

Welcome [@&#8203;Bamieh] and [@&#8203;xxczaki] to the team!
#### :bug: Fixes

- [#&#8203;2661]: `progress` reporter now accepts reporter options ([@&#8203;canoztokmak])
- [#&#8203;3142]: `xit` in `bdd` interface now properly returns its `Test` object ([@&#8203;Bamieh])
- [#&#8203;3075]: Diffs now computed eagerly to avoid misinformation when reported ([@&#8203;abrady0])
- [#&#8203;2745]: `--help` will now help you even if you have a `mocha.opts` ([@&#8203;Zarel])
#### :tada: Enhancements

- [#&#8203;2514]: The `--no-diff` flag will completely disable diff output ([@&#8203;CapacitorSet])
- [#&#8203;3058]: All "setters" in Mocha's API are now also "getters" if called without arguments ([@&#8203;makepanic])
#### :book: Documentation

- [#&#8203;3170]: Optimization and site speed improvements ([@&#8203;Munter])
- [#&#8203;2987]: Moved the old [site repo](https://github.com/mochajs/mochajs.github.io) into the main repo under `docs/` ([@&#8203;boneskull])
- [#&#8203;2896]: Add [maintainer guide](https://github.com/mochajs/mocha/blob/master/MAINTAINERS.md) ([@&#8203;boneskull])
- Various fixes and updates ([@&#8203;xxczaki], [@&#8203;maty21], [@&#8203;leedm777])
#### :nut_and_bolt: Other

- Test improvements and fixes ([@&#8203;eugenet8k], [@&#8203;ngeor], [@&#8203;38elements], [@&#8203;Gerhut], [@&#8203;ScottFreeCode], [@&#8203;boneskull])
- Refactoring and cruft excision ([@&#8203;38elements], [@&#8203;Bamieh], [@&#8203;finnigantime], [@&#8203;boneskull])

[#&#8203;2661]: `https://github.com/mochajs/mocha/issues/2661`
[#&#8203;3142]: `https://github.com/mochajs/mocha/issues/3142`
[#&#8203;3075]: `https://github.com/mochajs/mocha/pull/3075`
[#&#8203;2745]: `https://github.com/mochajs/mocha/issues/2745`
[#&#8203;2514]: `https://github.com/mochajs/mocha/issues/2514`
[#&#8203;3058]: `https://github.com/mochajs/mocha/issues/3058`
[#&#8203;3170]: `https://github.com/mochajs/mocha/pull/3170`
[#&#8203;2987]: `https://github.com/mochajs/mocha/issues/2987`
[#&#8203;2896]: `https://github.com/mochajs/mocha/issues/2896`
[@&#8203;canoztokmak]: https://github.com/canoztokmak
[@&#8203;Bamieh]: https://github.com/Bamieh
[@&#8203;abrady0]: https://github.com/abrady0
[@&#8203;Zarel]: https://github.com/Zarel
[@&#8203;CapacitorSet]: https://github.com/CapacitorSet
[@&#8203;xxczaki]: https://github.com/xxczaki
[@&#8203;maty21]: https://github.com/maty21
[@&#8203;leedm777]: https://github.com/leedm777
[@&#8203;eugenet8k]: https://github.com/eugenet8k
[@&#8203;38elements]: https://github.com/38elements
[@&#8203;Gerhut]: https://github.com/Gerhut
[@&#8203;finnigantime]: https://github.com/finnigantime

---

### [`v5.0.0`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;500--2018-01-17)

Mocha starts off 2018 right by again dropping support for *unmaintained rubbish*.

Welcome [@&#8203;vkarpov15] to the team!
#### :boom: Breaking Changes

- **[#&#8203;3148]: Drop support for IE9 and IE10** ([@&#8203;Bamieh])
  Practically speaking, only code which consumes (through bundling or otherwise) the userland [buffer](https://npm.im/buffer) module should be affected.  However, Mocha will no longer test against these browsers, nor apply fixes for them.
#### :tada: Enhancements

- [#&#8203;3181]: Add useful new `--file` command line argument ([documentation](https://mochajs.org/#--file-file)) ([@&#8203;hswolff])
#### :bug: Fixes

- [#&#8203;3187]: Fix inaccurate test duration reporting ([@&#8203;FND])
- [#&#8203;3202]: Fix bad markup in HTML reporter ([@&#8203;DanielRuf])
#### :sunglasses: Developer Experience

- [#&#8203;2352]: Ditch GNU Make for [nps](https://npm.im/nps) to manage scripts ([@&#8203;TedYav])
#### :book: Documentation

- [#&#8203;3137]: Add missing `--no-timeouts` docs ([@&#8203;dfberry])
- [#&#8203;3134]: Improve `done()` callback docs ([@&#8203;maraisr])
- [#&#8203;3135]: Fix cross-references ([@&#8203;vkarpov15])
- [#&#8203;3163]: Fix tpyos ([@&#8203;tbroadley])
- [#&#8203;3177]: Tweak `README.md` organization ([@&#8203;xxczaki])
- Misc updates ([@&#8203;boneskull])
#### :nut_and_bolt: Other

- [#&#8203;3118]: Move TextMate Integration to [its own repo](https://github.com/mochajs/mocha.tmbundle) ([@&#8203;Bamieh])
- [#&#8203;3185]: Add Node.js v9 to build matrix; remove v7 ([@&#8203;xxczaki])
- [#&#8203;3172]: Markdown linting ([@&#8203;boneskull])
- Test & Netlify updates ([@&#8203;Munter], [@&#8203;boneskull])

[#&#8203;3148]: `https://github.com/mochajs/mocha/issues/3148`
[#&#8203;3181]: `https://github.com/mochajs/mocha/issues/3181`
[#&#8203;3187]: `https://github.com/mochajs/mocha/issues/3187`
[#&#8203;3202]: `https://github.com/mochajs/mocha/pull/3202`
[#&#8203;2352]: `https://github.com/mochajs/mocha/issues/2352`
[#&#8203;3137]: `https://github.com/mochajs/mocha/issues/3137`
[#&#8203;3134]: `https://github.com/mochajs/mocha/issues/3134`
[#&#8203;3135]: `https://github.com/mochajs/mocha/issues/3135`
[#&#8203;3163]: `https://github.com/mochajs/mocha/pull/3163`
[#&#8203;3177]: `https://github.com/mochajs/mocha/pull/3177`
[#&#8203;3118]: `https://github.com/mochajs/mocha/issues/3118`
[#&#8203;3185]: `https://github.com/mochajs/mocha/issues/3185`
[#&#8203;3172]: `https://github.com/mochajs/mocha/issues/3172`
[@&#8203;hswolff]: https://github.com/hswolff
[@&#8203;FND]: https://github.com/FND
[@&#8203;DanielRuf]: https://github.com/DanielRuf
[@&#8203;TedYav]: https://github.com/TedYav
[@&#8203;dfberry]: https://github.com/dfberry
[@&#8203;maraisr]: https://github.com/maraisr
[@&#8203;vkarpov15]: https://github.com/vkarpov15
[@&#8203;tbroadley]: https://github.com/tbroadley

---

### [`v5.0.1`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;501--2018-02-07)

...your garden-variety patch release.

Special thanks to [Wallaby.js](https://wallabyjs.com) for their continued support! :heart:
#### :bug: Fixes

- [#&#8203;1838]: `--delay` now works with `.only()` ([@&#8203;silviom])
- [#&#8203;3119]: Plug memory leak present in v8 ([@&#8203;boneskull])
#### :book: Documentation

- [#&#8203;3132], [#&#8203;3098]: Update `--glob` docs ([@&#8203;outsideris])
- [#&#8203;3212]: Update [Wallaby.js](https://wallabyjs.com)-related docs ([@&#8203;ArtemGovorov])
- [#&#8203;3205]: Remove outdated cruft ([@&#8203;boneskull])
#### :nut_and_bolt: Other

- [#&#8203;3224]: Add proper Wallaby.js config ([@&#8203;ArtemGovorov])
- [#&#8203;3230]: Update copyright year ([@&#8203;josephlin55555])

[#&#8203;1838]: `https://github.com/mochajs/mocha/issues/1838`
[#&#8203;3119]: `https://github.com/mochajs/mocha/issues/3119`
[#&#8203;3132]: `https://github.com/mochajs/mocha/issues/3132`
[#&#8203;3098]: `https://github.com/mochajs/mocha/issues/3098`
[#&#8203;3212]: `https://github.com/mochajs/mocha/pull/3212`
[#&#8203;3205]: `https://github.com/mochajs/mocha/pull/3205`
[#&#8203;3224]: `https://github.com/mochajs/mocha/pull/3224`
[#&#8203;3230]: `https://github.com/mochajs/mocha/pull/3230`
[@&#8203;silviom]: https://github.com/silviom
[@&#8203;outsideris]: https://github.com/outsideris
[@&#8203;ArtemGovorov]: https://github.com/ArtemGovorov
[@&#8203;josephlin55555]: https://github.com/josephlin55555

---

### [`v5.0.2`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;502--2018-03-05)

This release fixes a class of tests which report as *false positives*.  **Certain tests will now break**, though they would have previously been reported as passing.  Details below.  Sorry for the inconvenience!
#### :bug: Fixes

- [#&#8203;3226]: Do not swallow errors that are thrown asynchronously from passing tests ([@&#8203;boneskull]).  Example:

  ```js
  it('should actually fail, sorry!', function (done) {
    // passing assertion
    assert(true === true);

    // test complete & is marked as passing
    done();

    // ...but something evil lurks within
    setTimeout(() => {
      throw new Error('chaos!');
    }, 100);
  });
  ```

  Previously to this version, Mocha would have *silently swallowed* the `chaos!` exception, and you wouldn't know.  Well, *now you know*.  Mocha cannot recover from this gracefully, so it will exit with a nonzero code.

  **Maintainers of external reporters**: *If* a test of this class is encountered, the `Runner` instance will emit the `end` event *twice*; you *may* need to change your reporter to use `runner.once('end')` intead of `runner.on('end')`.
- [#&#8203;3093]: Fix stack trace reformatting problem ([@&#8203;outsideris])
#### :nut_and_bolt: Other

- [#&#8203;3248]: Update `browser-stdout` to v1.3.1 ([@&#8203;honzajavorek])

[#&#8203;3248]: `https://github.com/mochajs/mocha/issues/3248`
[#&#8203;3226]: `https://github.com/mochajs/mocha/issues/3226`
[#&#8203;3093]: `https://github.com/mochajs/mocha/issues/3093`
[@&#8203;honzajavorek]: https://github.com/honzajavorek

---

### [`v5.0.3`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;503--2018-03-06)

This patch features a fix to address a potential "low severity" [ReDoS vulnerability](https://snyk.io/vuln/npm:diff:20180305) in the [diff](https://npm.im/diff) package (a dependency of Mocha).
#### :lock: Security Fixes

- [#&#8203;3266]: Bump `diff` to v3.5.0 ([@&#8203;anishkny])
#### :nut_and_bolt: Other

- [#&#8203;3011]: Expose `generateDiff()` in `Base` reporter ([@&#8203;harrysarson])

[#&#8203;3266]: `https://github.com/mochajs/mocha/pull/3266`
[#&#8203;3011]: `https://github.com/mochajs/mocha/issues/3011`

[@&#8203;anishkny]: https://github.com/anishkny
[@&#8203;harrysarson]: https://github.com/harrysarson

---

### [`v5.0.4`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;504--2018-03-07)

#### :bug: Fixes

- [#&#8203;3265]: Fixes regression in "watch" functionality introduced in v5.0.2 ([@&#8203;outsideris])

[#&#8203;3265]: `https://github.com/mochajs/mocha/issues/3265`

---

### [`v5.0.5`](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#&#8203;505--2018-03-22)

Welcome [@&#8203;outsideris] to the team!
#### :bug: Fixes

- [#&#8203;3096]: Fix `--bail` failing to bail within hooks ([@&#8203;outsideris])
- [#&#8203;3184]: Don't skip too many suites (using `describe.skip()`) ([@&#8203;outsideris])
#### :book: Documentation

- [#&#8203;3133]: Improve docs regarding "pending" behavior ([@&#8203;ematicipo])
- [#&#8203;3276], [#&#8203;3274]: Fix broken stuff in `CHANGELOG.md` ([@&#8203;tagoro9], [@&#8203;honzajavorek])
#### :nut_and_bolt: Other

- [#&#8203;3208]: Improve test coverage for AMD users ([@&#8203;outsideris])
- [#&#8203;3267]: Remove vestiges of PhantomJS from CI ([@&#8203;anishkny])
- [#&#8203;2952]: Fix a debug message ([@&#8203;boneskull])

[#&#8203;3096]: `https://github.com/mochajs/mocha/issues/3096`
[#&#8203;3184]: `https://github.com/mochajs/mocha/issues/3184`
[#&#8203;3133]: `https://github.com/mochajs/mocha/issues/3133`
[#&#8203;3276]: `https://github.com/mochajs/mocha/pull/3276`
[#&#8203;3274]: `https://github.com/mochajs/mocha/pull/3274`
[#&#8203;3208]: `https://github.com/mochajs/mocha/issues/3208`
[#&#8203;2952]: `https://github.com/mochajs/mocha/issues/2952`
[#&#8203;3267]: `https://github.com/mochajs/mocha/pull/3267`

[@&#8203;ematicipo]: https://github.com/ematicipo
[@&#8203;tagoro9]: https://github.com/tagoro9
[@&#8203;honzajavorek]: https://github.com/honajavorek
[@&#8203;anishkny]: https://github.com/anishkny

---

</details>


<details>
<summary>Commits</summary>

#### v4.1.0
-   [`a4b684d`](https://github.com/mochajs/mocha/commit/a4b684dfaf5bb0c915415f32d0179aa929609c54) Added netlify header auto generation
-   [`4b18851`](https://github.com/mochajs/mocha/commit/4b188511a1101afe01c44bf4c1337585d075d5d4) Externalise js bundles
-   [`d5a5125`](https://github.com/mochajs/mocha/commit/d5a512563d0e845b57a2fed1320b120cb51a1067) Be explicit about styling of screenshot images
-   [`8f1ded4`](https://github.com/mochajs/mocha/commit/8f1ded4e82b36df67b84347199adffe03fe8ffbe) https urls where possible
-   [`64deadc`](https://github.com/mochajs/mocha/commit/64deadce3b4175eb41c965e1fa8024b2d11e9c5a) Specific value for inlining htmlimages to guarantee logo is inlined
-   [`123ee4f`](https://github.com/mochajs/mocha/commit/123ee4f42388700eb16c85630ae23a3e298bc70f) Handle the case where all avatars are already loaded at the time when the script exexecutes
-   [`bd5109e`](https://github.com/mochajs/mocha/commit/bd5109eb7e53c5996b7e2a748e37f6afce9ba808) Remove crossorigin&#x3D;&#x27;anonymous&#x27; from preconnect hints. Only needed for fonts, xhr and es module loads
-   [`119543e`](https://github.com/mochajs/mocha/commit/119543e2ac1f016cff9caaf533acbd9ad3457472) Add preconnect for doubleclick domain that google analytics results in contacting
-   [`3abed9b`](https://github.com/mochajs/mocha/commit/3abed9bcf2f763b97aecc57066718a5f62bd9833) Lint netlify-headers script
-   [`4a6e095`](https://github.com/mochajs/mocha/commit/4a6e095b889c78bb70c38a0d79792e4992ba4241) Run appveyor tests on x64 platform. Might enable sharp installation
-   [`33db6b1`](https://github.com/mochajs/mocha/commit/33db6b119c471fc275d61795ba6767eea8979ebb) Use x64 node on appveyor
-   [`ae3712c`](https://github.com/mochajs/mocha/commit/ae3712cf2f6e2323faef1d3293cb38c8c62b4dc6) [ImgBot] optimizes images (#&#8203;3175)
-   [`adc67fd`](https://github.com/mochajs/mocha/commit/adc67fd741c768d8687995158632fabf41a7c1f0) Revert &quot;[ImgBot] optimizes images (#&#8203;3175)&quot;
-   [`ea96b18`](https://github.com/mochajs/mocha/commit/ea96b18249a9e1b9236fe55c2806e32f21e6d63a) add .fossaignore [ci skip]
-   [`5be22b2`](https://github.com/mochajs/mocha/commit/5be22b23480f27679fbc0d6dd21ce6e4085029c4) `options.reporterOptions` are used for progress reporter
-   [`3c4b116`](https://github.com/mochajs/mocha/commit/3c4b11650450a60c042a2ad2feaa7d293b23790f) update CHANGELOG for v4.1.0
-   [`6b9ddc6`](https://github.com/mochajs/mocha/commit/6b9ddc64e27d8700aa6d2cc8d0bb4b47b32d6768) Release v4.1.0
#### v5.0.0
-   [`c1da848`](https://github.com/mochajs/mocha/commit/c1da848baee744fedb10ff55cf3c6c738b476aef) Update README.md
-   [`5161639`](https://github.com/mochajs/mocha/commit/51616395ee584fea4ef0d71d243244bc571375ce) Fix typos
-   [`ef981a2`](https://github.com/mochajs/mocha/commit/ef981a2794e564ccb08a48deeaf0450517ad054b) Link to unexpected.js on http. Cert errors on https
-   [`3e85f89`](https://github.com/mochajs/mocha/commit/3e85f89026ccdfb874fa523641e6d3da94a57b61) Ensure consistent calculation of duration
-   [`a554adb`](https://github.com/mochajs/mocha/commit/a554adb7bd672e3118ab3f43d4258f5c39baf768) Update .travis.yml
-   [`3f314b6`](https://github.com/mochajs/mocha/commit/3f314b619174174d4f406ba610f95f4bdf652943) drop support for ie9 and ie10; closes `https://github.com/mochajs/mocha/issues/3148`
-   [`95d2fe7`](https://github.com/mochajs/mocha/commit/95d2fe7d113852fc584cda4dbb79510d4b79271c) Update karma.conf.js
-   [`dc12bd5`](https://github.com/mochajs/mocha/commit/dc12bd5ce81dfaf5dda290c5387024be7936117a) test setup for ESM support
-   [`a723b8f`](https://github.com/mochajs/mocha/commit/a723b8f8da2977b5f7620c0cdbdb299a09ee78e4) lint Markdown; closes #&#8203;3172
-   [`b2697a7`](https://github.com/mochajs/mocha/commit/b2697a7f5fca1e953474b7ba9722d9ec98363111) add --no-timeouts to docs; closes #&#8203;3137  (#&#8203;3176)
-   [`cb09e8b`](https://github.com/mochajs/mocha/commit/cb09e8bc752a4ad506dcb9c3c4def8dbd1c6622f) document Error/undefined params to the &#x27;done&#x27; callback; closes #&#8203;3134
-   [`e54370e`](https://github.com/mochajs/mocha/commit/e54370eaa4b16db96f14157fdce06272e2b4ec68) replace phantomjs with puppeteer for browser tests; closes #&#8203;3128
-   [`565726d`](https://github.com/mochajs/mocha/commit/565726d8d4d17a6dc8683c08a43cf236d720e37e) Added Netlify config file
-   [`e8b5592`](https://github.com/mochajs/mocha/commit/e8b55925d6e80e01f824c99a1fae63148a132671) Align netlify config with admin panel
-   [`ac1dd70`](https://github.com/mochajs/mocha/commit/ac1dd704bce4f68a1b4044f748790c20b34e04c2) attempt to get travis working again
-   [`5c6e99b`](https://github.com/mochajs/mocha/commit/5c6e99b50bd2a17c03a5ae6b52862bc60121bd91) update ESM tests to run against headless chrome instead of saucelabs&#x27; chrome only
-   [`c7730a6`](https://github.com/mochajs/mocha/commit/c7730a623fd7398b968b0a3f00ad9574f31715af) Drop TextMate integration inside mocha closes `https://github.com/mochajs/mocha/issues/3118`
-   [`0a3e32b`](https://github.com/mochajs/mocha/commit/0a3e32b81b3ca65c6795cce04fc9d9a8ad9f7a1c) Rewrite Makefile using NPS Scripts. Closes #&#8203;2352
-   [`7d8abe0`](https://github.com/mochajs/mocha/commit/7d8abe0168f74bd4551a73965d2f7ff42015203e) fix id and class definition
-   [`50aec7a`](https://github.com/mochajs/mocha/commit/50aec7a249c7b2a28e2fdc18058829f48e6ee6d6) Add ability to pass in test files to be ran before positional files via --file (#&#8203;3190)
-   [`401997f`](https://github.com/mochajs/mocha/commit/401997f44dc54177d1f2dc74954be29df5e29d1d) update package-lock.json
-   [`f8a1d2a`](https://github.com/mochajs/mocha/commit/f8a1d2a388f1a7fb25313703ee128f3cc7567656) docs(index): add missing doc link (#&#8203;3203); closes #&#8203;3135
-   [`dc58252`](https://github.com/mochajs/mocha/commit/dc5825291be779122bea31fbf46593859eed638e) prep changelog for v5.0.0 [ci skip]
-   [`a7267b4`](https://github.com/mochajs/mocha/commit/a7267b4b49c423abe0924e865597caa1750416c6) remove more references to make and Makefile
-   [`9f61c04`](https://github.com/mochajs/mocha/commit/9f61c04db6f880acd9ca0dc2ca629e996fb3ab8d) finalize v5.0.0 CHANGELOG [ci skip]
-   [`cc4a818`](https://github.com/mochajs/mocha/commit/cc4a8183ae63974297d74442a9787bcb8c78fd28) Release v5.0.0
#### v5.0.1
-   [`c0ac1b9`](https://github.com/mochajs/mocha/commit/c0ac1b96a5856c9ae6a4fdd028f1bb89593f723a) fix travis &quot;before script&quot; script
-   [`2fe2d01`](https://github.com/mochajs/mocha/commit/2fe2d0116e80f37956fcf799c96276ffb8dddab5) Revert &quot;fix travis &quot;before script&quot; script&quot;
-   [`bca57f4`](https://github.com/mochajs/mocha/commit/bca57f438037b7ce2906b4b8f7ab4b9fba5d8102) clarify docs on html, xunit and 3p reporters; closes #&#8203;1906
-   [`2e7e4c0`](https://github.com/mochajs/mocha/commit/2e7e4c0c576996b87ca5a3bf226953bfa978d97a) rename &quot;common-mistake&quot; label to &quot;faq&quot;
-   [`14fc030`](https://github.com/mochajs/mocha/commit/14fc03090413b038672ca80fd9cbbfb0ccfc0826) Add all supported wallaby editors
-   [`f687d2b`](https://github.com/mochajs/mocha/commit/f687d2b0fb2e04b9ec9edfdfe58ce3ea513de369) update docs for the glob
-   [`cd74322`](https://github.com/mochajs/mocha/commit/cd743228f0999ebfe8f88f224d6d61bc063de8ed) Slight copy update on docs for test directory
-   [`b57f623`](https://github.com/mochajs/mocha/commit/b57f6234b75a1b25e0244ad9d04c4451414ee321) fix: When using --delay, .only() no longer works. Issue  #&#8203;1838
-   [`3509029`](https://github.com/mochajs/mocha/commit/3509029e5da38daca0d650094117600b6617a862) update .gitignore to only ignore root mocha.js [ci skip]
-   [`d975a6a`](https://github.com/mochajs/mocha/commit/d975a6a8455edb07477dc37a427c268aa59713ff) fix memory leak when run in v8; closes #&#8203;3119
-   [`b7377b3`](https://github.com/mochajs/mocha/commit/b7377b380202d2c0d5634dcb89dc50ea69961fb3) rename help-wanted to &quot;help wanted&quot; in stale.yml
-   [`412cf27`](https://github.com/mochajs/mocha/commit/412cf278784d56b04dc165f88e8fb7999f437958) [Update] license year
-   [`44aae9f`](https://github.com/mochajs/mocha/commit/44aae9f66db2efca550e5c9ac0dedaeac52d7e9e) add working wallaby config
-   [`70027b6`](https://github.com/mochajs/mocha/commit/70027b60da7f409a40ea267e207aceac1ec1d286) update changelog for v5.0.1 [ci skip]
-   [`09ce746`](https://github.com/mochajs/mocha/commit/09ce746aa925d35317f2624fd36c77a31bb68e24) Release v5.0.1
-   [`73d55ac`](https://github.com/mochajs/mocha/commit/73d55ac4bc2d1f10121e6d37e62f2bff7520f166) fix typos in changelog [ci skip]
-   [`c4ef568`](https://github.com/mochajs/mocha/commit/c4ef5687fa67ab97642a66ec25e05139e2d333ce) fix PR url
#### v5.0.2
-   [`f71f347`](https://github.com/mochajs/mocha/commit/f71f3472d1049737ce0e2d2131753b468d45c66a) rename wallaby.js -&gt; .wallaby.js
-   [`ec8901a`](https://github.com/mochajs/mocha/commit/ec8901a23c5194b6f7e6eee9c2568e5020c944ce) remove unused functionality in utils module
-   [`3537061`](https://github.com/mochajs/mocha/commit/3537061613886f9d37c0889d16f64dbdaf1583db) Update to correctly licensed browser-stdout version
-   [`2c720a3`](https://github.com/mochajs/mocha/commit/2c720a35000da0fecf11ef65c20ca4292c226ad7) do not eat exceptions thrown asynchronously from passed tests; closes #&#8203;3226
-   [`5078fc5`](https://github.com/mochajs/mocha/commit/5078fc5325bf7bd02b6cf448792cd1584e052b73) persist paths in stack trace which have cwd as infix
-   [`3792bef`](https://github.com/mochajs/mocha/commit/3792bef67b59add3b6d188e53f4d324e1488f159) add opencollective header image to assets/
-   [`afcd08f`](https://github.com/mochajs/mocha/commit/afcd08f1fb6782d7d4f7d4d935250279f94d728a) add MAINTAINERS.md to .fossaignore [ci skip]
-   [`0542c40`](https://github.com/mochajs/mocha/commit/0542c407fcc08be3a3e293d5df943f22d292e304) update README.md; closes #&#8203;3191 [ci skip]
-   [`6a796cb`](https://github.com/mochajs/mocha/commit/6a796cbbcd6c9f805e482c424327c82ed0398dbf) prepare CHANGELOG for v5.0.2 [ci skip]
-   [`ff1bd9e`](https://github.com/mochajs/mocha/commit/ff1bd9eaa491a29d67fa6742766464efeb82ac29) update package-lock.json
-   [`f2ee53c`](https://github.com/mochajs/mocha/commit/f2ee53c5ae4583b8117b842ffdbce6ed7387bcaf) Release v5.0.2
#### v5.0.3
-   [`bdcb3c3`](https://github.com/mochajs/mocha/commit/bdcb3c371b2261101609b8c5feb4c6eb539223fb) exposes generateDiff function from base reporter
-   [`660bccc`](https://github.com/mochajs/mocha/commit/660bcccdb70282cd160c2e18d750fc1dbe2f6a34) adds unit tests covering Base.generateDiff
-   [`8df5727`](https://github.com/mochajs/mocha/commit/8df5727478a1a9294045ace7d67c4d192ee5dda0) Tidies up code after review
-   [`aaaa5ab`](https://github.com/mochajs/mocha/commit/aaaa5abdd72e6d9db446c3c0d414947241ce6042) fix: ReDoS vuln in mocha@&#8203;5.0.2 › diff@&#8203;3.3.1 (#&#8203;3266)
-   [`70d9262`](https://github.com/mochajs/mocha/commit/70d9262d0f13906734e87e33f99afe3f4d61dff8) update CHANGELOG.md for v5.0.3 [ci skip]
-   [`da6e5c9`](https://github.com/mochajs/mocha/commit/da6e5c967af4284c48ebd35adebdf5c76d1becd1) Release v5.0.3
#### v5.0.4
-   [`eb09421`](https://github.com/mochajs/mocha/commit/eb094216bc022efd0557316b6615bda392613443) restore removed methods which still used
-   [`868830a`](https://github.com/mochajs/mocha/commit/868830ae4355fa2dbe6184431ddddc8a84bfecdd) update CHANGELOG.md for v5.0.4 [ci skip]
-   [`851ad29`](https://github.com/mochajs/mocha/commit/851ad29309b16878ad7c755158db263337cc4995) Release v5.0.4
#### v5.0.5
-   [`aa592f4`](https://github.com/mochajs/mocha/commit/aa592f45bf3895ba38ff975d809b4a0e23d289ad) update package-lock.json
-   [`85cb5c1`](https://github.com/mochajs/mocha/commit/85cb5c1bf85ee6602d75460fe299a4ea9848298b) add .vscode/ to .gitignore
-   [`3d09381`](https://github.com/mochajs/mocha/commit/3d09381290530108b8734f0aeaf9bcf35eded55f) add Karma &quot;ChromeDebug&quot; custom launcher for VSCode [ci skip]
-   [`e19e879`](https://github.com/mochajs/mocha/commit/e19e879ef412f5d6dc3214c3a154c384b04e6403) ensure lib/mocha.js is not ignored by ESLint
-   [`86af6bb`](https://github.com/mochajs/mocha/commit/86af6bb0349fb7522e9a062a9d06c7fc020971c0) fix my carelessness in e19e879
-   [`d76f490`](https://github.com/mochajs/mocha/commit/d76f490fe2f4b827712a0f8874e9cc702f507db4) chore(ci): Remove PHANTOMJS_CDNURL, nit
-   [`27af2cf`](https://github.com/mochajs/mocha/commit/27af2cf158eb9bdcf57037555bbe79cde41afccd) fix(changelog): update links to some PRs
-   [`39df783`](https://github.com/mochajs/mocha/commit/39df7838d1d8e67e8972f1c6558acd62692a3aac) docs: Fix typo in an emoji
-   [`0060884`](https://github.com/mochajs/mocha/commit/0060884cfab435ab07480c885aeb34643cbcf79b) keep hierarchy for skipped suites w/o a callback
-   [`6383916`](https://github.com/mochajs/mocha/commit/638391684a5a07a9868bb102c01a81f84434fcc1) fix to bail option works properly with hooks (#&#8203;3278)
-   [`ab84f02`](https://github.com/mochajs/mocha/commit/ab84f02e1ab0bdf11d4201a2a5acb131053f6695) chore(docs): rewording pending tests
-   [`2c19503`](https://github.com/mochajs/mocha/commit/2c19503e4a5df40ea811ce436328ab0b56949e2d) Fixed linting
-   [`19b764d`](https://github.com/mochajs/mocha/commit/19b764dcb19a27ed410067373411d840042d815d) Addressed feedback
-   [`f4275b6`](https://github.com/mochajs/mocha/commit/f4275b67c0c4e8ac863fe75b5d1bf4a78ce8cda9) extract checking AMD bundle as own test
-   [`19104e3`](https://github.com/mochajs/mocha/commit/19104e3cef7a7e8ba5c8be5b3b7cde924b8428e4) fix debug msg in Runnable#slow; closes #&#8203;2952
-   [`424ef84`](https://github.com/mochajs/mocha/commit/424ef84dbaf6f6a267102d48ef0750e939e9ddd8) increase default timeout for browser unit tests
-   [`3633fa0`](https://github.com/mochajs/mocha/commit/3633fa0061064bda98bfd6a10a6f1c5d518b87f7) append filepath to &quot;timeout exceeded&quot; exception; closes #&#8203;627- all `Runnable`s *should* now have a `file` property- filepath is appended to the `Error` message in parens- DRY-style refactors
-   [`c580294`](https://github.com/mochajs/mocha/commit/c580294893e1bf2f9e51adafd73e6cac71690d19) remove default js in &quot;--watch-extensions&quot; option; closes #&#8203;3275

</details>